### PR TITLE
feat: add nhentai

### DIFF
--- a/.github/workflows/hitomi-db.yml
+++ b/.github/workflows/hitomi-db.yml
@@ -37,7 +37,7 @@ jobs:
         continue-on-error: true
         run: |
           uv run python -m utils.website.hitomi.scape_dataset \
-            --db-path assets/hitomi.db \
+            --db-path __temp/hitomi.db \
             --workers 2 \
             --max-retries 5 \
             --timeout 15
@@ -47,20 +47,20 @@ jobs:
         if: steps.scrape.outcome == 'failure'
         run: |
           uv run python -m utils.website.hitomi.scape_dataset \
-            --db-path assets/hitomi.db \
+            --db-path __temp/hitomi.db \
             --workers 1 \
             --max-retries 8 \
             --timeout 20 \
             --only-failed
 
       - name: Quality gate
-        run: uv run python .github/scripts/hitomi_db_gate.py assets/hitomi.db
+        run: uv run python .github/scripts/hitomi_db_gate.py __temp/hitomi.db
 
       - name: Generate manifest
         run: |
           uv run python .github/scripts/generate_hitomi_manifest.py \
-            assets/hitomi.db \
-            --output assets/hitomi-manifest.json
+            __temp/hitomi.db \
+            --output __temp/hitomi-manifest.json
 
       - name: Upload to release
         env:
@@ -74,13 +74,13 @@ jobs:
             gh release delete-asset "$TAG" hitomi.db --yes 2>/dev/null || true
             gh release delete-asset "$TAG" hitomi-manifest.json --yes 2>/dev/null || true
             gh release upload "$TAG" \
-              assets/hitomi.db \
-              assets/hitomi-manifest.json
+              __temp/hitomi.db \
+              __temp/hitomi-manifest.json
           else
             gh release create "$TAG" \
               --title "Preset Assets" \
               --notes "Auto-managed preset assets (hitomi.db, etc.)" \
               --latest=false \
-              assets/hitomi.db \
-              assets/hitomi-manifest.json
+              __temp/hitomi.db \
+              __temp/hitomi-manifest.json
           fi

--- a/ComicSpider/spiders/nhentai.py
+++ b/ComicSpider/spiders/nhentai.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+from utils.website import NhentaiUtils
+
+from .basecomicspider import BaseComicSpider2, font_color
+
+
+class NhentaiSpider(BaseComicSpider2):
+    custom_settings = {
+        "DOWNLOADER_MIDDLEWARES": {
+            "ComicSpider.middlewares.ComicDlAllProxyMiddleware": 5,
+            "ComicSpider.middlewares.UAMiddleware": 6,
+            "ComicSpider.middlewares.RefererMiddleware": 10,
+        }
+    }
+    name = "nhentai"
+    num_of_row = 4
+    domain = NhentaiUtils.domain
+    search_url_head = NhentaiUtils.search_url_head
+    turn_page_info = NhentaiUtils.turn_page_info
+    book_id_url = NhentaiUtils.gallery_api_url_template
+    mappings = dict(NhentaiUtils.mappings)
+
+    @property
+    def ua(self):
+        return dict(NhentaiUtils.headers)
+
+    def frame_section(self, response):
+        detail = self.spider_site_runtime.parser.parse_book(response.text)
+        book = response.meta.get("book") or detail
+        if book is not detail:
+            self.spider_site_runtime.parser.apply_detail(book, detail)
+        frame_results = self.spider_site_runtime.parser.build_page_image_map(book)
+        if not frame_results:
+            raise ValueError("nhentai gallery detail produced empty image map")
+        self.say("📢" + font_color(" 这本已经扔进任务了", cls="theme-tip"))
+        return frame_results

--- a/GUI/mainwindow.py
+++ b/GUI/mainwindow.py
@@ -62,6 +62,8 @@ class MitmMainWindow(Ui_MainWindow):
         self.chooseBox.setItemText(8, _translate("MainWindow", "8、h-comic🔞"))
         self.chooseBox.addItem("")
         self.chooseBox.setItemText(9, _translate("MainWindow", "9、jestful"))
+        self.chooseBox.addItem("")
+        self.chooseBox.setItemText(10, _translate("MainWindow", "10、nhentai🔞"))
         self.chooseBox.setCurrentIndex(0)
         self.domainBtn = TransparentToolButton(QIcon(':/main/publish.svg'), self)
         self.domainBtn.setVisible(False)

--- a/GUI/manager/async_task.py
+++ b/GUI/manager/async_task.py
@@ -5,6 +5,7 @@
 import asyncio
 from dataclasses import dataclass, field
 import inspect
+import math
 import time
 import traceback
 from typing import Any, Callable, Dict, List, Optional, Tuple
@@ -33,6 +34,86 @@ def summarize_error_message(message: object, *, max_length: int = 180) -> str:
     has_hidden_detail = clipped or len(text.splitlines()) > 1
     return f"{first_line}。详情见日志" if has_hidden_detail else first_line
 
+
+class AsyncTaskProgressReporter:
+    def __init__(self, emit: Callable[[str], None], *, throttle_seconds: float = 0.2, min_percent_step: int = 1):
+        self._emit = emit
+        self._throttle_seconds = throttle_seconds
+        self._min_percent_step = min_percent_step
+        self._label = ""
+        self._bytes_downloaded = 0
+        self._total_bytes: Optional[int] = None
+        self._last_emit_at = 0.0
+        self._last_percent = -1
+
+    def __call__(self, message: str):
+        self._emit(message)
+
+    def download_reset(self, *, label: Optional[str] = None):
+        self._label = label or self._label
+        self._bytes_downloaded = 0
+        self._total_bytes = None
+        self._last_emit_at = 0.0
+        self._last_percent = -1
+
+    def download_start(self, *, label: str, total_bytes: Optional[int] = None):
+        self.download_reset(label=label)
+        self._total_bytes = total_bytes if total_bytes is not None and total_bytes > 0 else None
+        if self._total_bytes is None:
+            self._emit(f"{self._label} 0B")
+            return
+        self._emit(f"{self._label} 0% {self._format_ratio(0, self._total_bytes)}")
+
+    def download_advance(self, chunk_size: int, *, label: Optional[str] = None, total_bytes: Optional[int] = None):
+        if chunk_size < 0:
+            raise ValueError("chunk_size must be >= 0")
+        if label:
+            self._label = label
+        if total_bytes is not None:
+            self._total_bytes = total_bytes if total_bytes > 0 else None
+        self._bytes_downloaded += chunk_size
+        now = time.monotonic()
+        if self._total_bytes is None:
+            if now - self._last_emit_at < self._throttle_seconds:
+                return
+            self._last_emit_at = now
+            self._emit(f"{self._label} {self._format_bytes(self._bytes_downloaded)}")
+            return
+
+        percent = min(100, math.floor((self._bytes_downloaded * 100) / self._total_bytes))
+        should_emit = percent >= self._last_percent + self._min_percent_step or now - self._last_emit_at >= self._throttle_seconds
+        if not should_emit:
+            return
+        self._last_emit_at = now
+        self._last_percent = percent
+        self._emit(f"{self._label} {percent}% {self._format_ratio(self._bytes_downloaded, self._total_bytes)}")
+
+    def download_finish(self, *, label: Optional[str] = None):
+        if label:
+            self._label = label
+        if self._total_bytes is None:
+            self._emit(f"{self._label} done {self._format_bytes(self._bytes_downloaded)}")
+            return
+        done_bytes = max(self._bytes_downloaded, self._total_bytes)
+        self._emit(f"{self._label} done {self._format_bytes(done_bytes)}")
+
+    @staticmethod
+    def _format_bytes(size_bytes: int) -> str:
+        if size_bytes < 1024:
+            return f"{size_bytes}B"
+        if size_bytes < 1024 * 1024:
+            return f"{size_bytes / 1024:.1f}K"
+        return f"{size_bytes / 1024 / 1024:.1f}M"
+
+    @classmethod
+    def _format_ratio(cls, downloaded_bytes: int, total_bytes: int) -> str:
+        if total_bytes < 1024:
+            return f"{downloaded_bytes}/{total_bytes}B"
+        if total_bytes < 1024 * 1024:
+            return f"{downloaded_bytes / 1024:.1f}/{total_bytes / 1024:.1f}K"
+        return f"{downloaded_bytes / 1024 / 1024:.1f}/{total_bytes / 1024 / 1024:.1f}M"
+
+
 class AsyncTaskThread(QThread):
     success_signal = Signal(object)
     error_signal = Signal(str)
@@ -52,7 +133,7 @@ class AsyncTaskThread(QThread):
                 return
             code_obj = getattr(self.task_func, "__code__", None)
             if code_obj is not None and "progress_callback" in code_obj.co_varnames:
-                self.kwargs["progress_callback"] = self.emit_progress
+                self.kwargs["progress_callback"] = AsyncTaskProgressReporter(self.emit_progress)
             result = self.task_func(*self.args, **self.kwargs)
             if inspect.isawaitable(result):
                 result = asyncio.run(result)
@@ -201,13 +282,8 @@ class TaskInfoBarCenter:
         if self._gui is None:
             return None
         infobar = factory(
-            title=title,
-            content=content,
-            orient=Qt.Horizontal,
-            isClosable=True,
-            position=InfoBarPosition.TOP,
-            duration=duration,
-            parent=self._gui,
+            title=title, content=content, orient=Qt.Horizontal, isClosable=True, position=InfoBarPosition.TOP,
+            duration=duration, parent=self._gui,
         )
         if infobar is None:
             return None
@@ -263,11 +339,7 @@ class AsyncTaskManager(QObject):
             )
             if config.show_tooltip:
                 self._tooltip_stack.show(
-                    task_id,
-                    config.tooltip_title,
-                    config.tooltip_content,
-                    config.tooltip_position,
-                    config.tooltip_parent,
+                    task_id, config.tooltip_title, config.tooltip_content, config.tooltip_position, config.tooltip_parent
                 )
             thread.start()
             return True
@@ -301,21 +373,11 @@ class AsyncTaskManager(QObject):
         return self.execute_task(
             task_id,
             TaskConfig(
-                task_func=task_func,
-                success_callback=success_callback,
-                error_callback=error_callback,
-                progress_callback=progress_callback,
-                tooltip_title=tooltip_title,
-                tooltip_content=tooltip_content,
-                show_success_info=show_success_info,
-                show_error_info=show_error_info,
-                success_message=success_message,
-                auto_hide_tooltip=auto_hide_tooltip,
-                show_tooltip=show_tooltip,
-                tooltip_position=tooltip_position,
-                tooltip_parent=tooltip_parent,
-                args=args,
-                kwargs=kwargs,
+                task_func=task_func, success_callback=success_callback, error_callback=error_callback,
+                progress_callback=progress_callback, tooltip_title=tooltip_title, tooltip_content=tooltip_content,
+                show_success_info=show_success_info, show_error_info=show_error_info, success_message=success_message,
+                auto_hide_tooltip=auto_hide_tooltip, show_tooltip=show_tooltip, tooltip_position=tooltip_position,
+                tooltip_parent=tooltip_parent, args=args, kwargs=kwargs,
             ),
         )
 

--- a/GUI/manager/preprocess.py
+++ b/GUI/manager/preprocess.py
@@ -1,8 +1,10 @@
+import asyncio
 import httpx
 from PySide6.QtCore import Qt, QObject
 from qfluentwidgets import InfoBar, InfoBarPosition
 
 from GUI.browser_window import BrowserWindow
+from GUI.core.timer import safe_single_shot
 from GUI.manager import _UpdateLauncher
 from GUI.manager.async_task import AsyncTaskManager
 from GUI.uic.qfluent.components import CustomInfoBar
@@ -13,7 +15,7 @@ from utils.website.preprocess import run_site_preprocess
 from variables import SPIDERS, VER, Spider
 
 
-data_cli = None
+data_cli: httpx.AsyncClient | None = None
 
 
 class PreprocessManager(QObject):
@@ -23,6 +25,8 @@ class PreprocessManager(QObject):
         self.show_err = conf.log_level.lower() == "debug"
         self.task_manager = AsyncTaskManager(gui)
         self._switch_generation = 0
+        self._active_preprocess: tuple[int, int] | None = None
+        self._queued_search: tuple[int, int, str] | None = None
 
     def _next_generation(self):
         self._switch_generation += 1
@@ -32,9 +36,9 @@ class PreprocessManager(QObject):
     def _reset_data_cli(self, proxies: list[str]):
         global data_cli
         if data_cli is not None:
-            data_cli.close()
+            asyncio.run(data_cli.aclose())
         transport = dict(proxy=f"http://{proxies[0]}", retries=2) if proxies else dict(retries=2)
-        data_cli = httpx.Client(transport=httpx.HTTPTransport(**transport))
+        data_cli = httpx.AsyncClient(transport=httpx.AsyncHTTPTransport(**transport))
 
     def handle_choosebox_changed(self, index: int, gui_site_runtime: GuiSiteRuntime | None):
         generation = self._next_generation()
@@ -42,6 +46,8 @@ class PreprocessManager(QObject):
         if gui_site_runtime is not None:
             proxies = gui_site_runtime.runtime_context.transport.proxies
         self._reset_data_cli(list(proxies))
+        self._active_preprocess = (index, generation)
+        self._queued_search = None
         self._sync_preview_runtime(index, gui_site_runtime, runtime_ready=False)
         self._start_preprocess(index, generation)
 
@@ -57,60 +63,63 @@ class PreprocessManager(QObject):
         self.gui.preview_mgr.handle_choosebox_changed(index, gui_site_runtime)
 
     def _start_preprocess(self, index: int, generation: int):
+        current_data_client = data_cli
+
         def task(progress_callback=None):
             if index == 7:
-                return run_site_preprocess(
-                    index,
-                    gui_site_runtime=None,
-                    conf_state=conf,
-                    data_client=data_cli,
-                    progress_callback=progress_callback,
-                )
+                return run_site_preprocess(index, gui_site_runtime=None, conf_state=conf, data_client=current_data_client,
+                    progress_callback=progress_callback)
             gui_site_runtime = self.gui.gui_site_runtime
             if gui_site_runtime is None:
                 raise RuntimeError("gui_site_runtime unavailable for preprocess flow")
-            return gui_site_runtime.preprocess(
-                conf_state=conf,
-                data_client=data_cli,
-                progress_callback=progress_callback,
-            )
+            return gui_site_runtime.preprocess(conf_state=conf, data_client=current_data_client, progress_callback=progress_callback)
 
         site_name = "Script" if index == 7 else SPIDERS.get(index, str(index))
         self.task_manager.execute_simple_task(
-            task_func=task,
-            success_callback=lambda result: self._on_preprocess_success(index, generation, result),
-            error_callback=lambda error: self._on_preprocess_error(index, generation, error),
-            show_error_info=self.show_err,
-            tooltip_title=f"{site_name} 预处理",
-            tooltip_content="处理中...",
+            task_func=task, success_callback=lambda result: self._on_preprocess_success(index, generation, result),
+            error_callback=lambda error: self._on_preprocess_error(index, generation, error), show_error_info=self.show_err,
+            tooltip_title=f"{site_name} 预处理", tooltip_content="处理中...",
             task_id=f"preprocess_{index}_{generation}",
         )
 
     def _on_preprocess_success(self, index: int, generation: int, result: PreprocessResult):
-        if not self._is_current_site(index, generation):
-            return
-        if not isinstance(result, PreprocessResult):
-            raise TypeError(f"unexpected preprocess result: {type(result)!r}")
+        try:
+            if not self._is_current_site(index, generation):
+                return
+            if not isinstance(result, PreprocessResult):
+                raise TypeError(f"unexpected preprocess result: {type(result)!r}")
 
-        if result.domain and index in SPIDERS:
-            self._refresh_runtime_domain(index, result.domain)
-        self._sync_preview_runtime(index, self.gui.gui_site_runtime, runtime_ready=result.runtime_ready)
-        if result.block_search:
-            self.gui.disable_start()
+            if result.domain and index in SPIDERS:
+                self._refresh_runtime_domain(index, result.domain)
+            self._sync_preview_runtime(index, self.gui.gui_site_runtime, runtime_ready=result.runtime_ready)
+            if result.block_search:
+                self.gui.disable_start()
 
-        for message in result.messages:
-            self._display_message(message)
-        for action in result.actions:
-            self._apply_action(action)
+            for message in result.messages:
+                self._display_message(message)
+            for action in result.actions:
+                self._apply_action(action)
+
+            self._dispatch_queued_search(
+                index,
+                generation,
+                ready=bool(result.runtime_ready and not result.block_search),
+            )
+        finally:
+            self._clear_active_preprocess(index, generation)
 
     def _on_preprocess_error(self, index: int, generation: int, error: str):
-        if not self._is_current_site(index, generation):
-            return
-        self._sync_preview_runtime(index, None, runtime_ready=False)
-        if index != Spider.HITOMI:
-            self.gui.disable_start()
-        self.gui.say("<br>❌ 预处理执行失败，请查看日志")
-        self.gui.log.error(error)
+        try:
+            if not self._is_current_site(index, generation):
+                return
+            self._sync_preview_runtime(index, None, runtime_ready=False)
+            if index != Spider.HITOMI:
+                self.gui.disable_start()
+            self.gui.say("<br>❌ 预处理执行失败，请查看日志")
+            self.gui.log.error(error)
+        finally:
+            self._clear_queued_search(index, generation)
+            self._clear_active_preprocess(index, generation)
 
     def _display_message(self, message: dict):
         channel = message.get("channel", "text")
@@ -175,12 +184,24 @@ class PreprocessManager(QObject):
             proxies = gui_site_runtime.runtime_context.transport.proxies
         self._reset_data_cli(list(proxies))
 
+    def queue_search_after_preprocess(self, index: int, keyword: str) -> bool:
+        active_preprocess = self._active_preprocess
+        if active_preprocess is None:
+            return False
+        active_index, generation = active_preprocess
+        if active_index != index or self.gui.chooseBox.currentIndex() != index:
+            return False
+        self._queued_search = (generation, index, keyword)
+        return True
+
     def cleanup(self):
         global data_cli
         self._next_generation()
+        self._active_preprocess = None
+        self._queued_search = None
         self.task_manager.reset()
         if data_cli is not None:
-            data_cli.close()
+            asyncio.run(data_cli.aclose())
             data_cli = None
 
     def _refresh_runtime_domain(self, index: int, domain: str | None):
@@ -192,3 +213,27 @@ class PreprocessManager(QObject):
         self.gui.gui_site_runtime = gui_site_runtime.with_domain(domain)
         if getattr(self.gui, "BrowserWindow", None):
             self.gui.BrowserWindow.apply_standard_environment()
+
+    def _dispatch_queued_search(self, index: int, generation: int, *, ready: bool):
+        queued_search = self._queued_search
+        if queued_search is None:
+            return
+        queued_generation, queued_index, keyword = queued_search
+        if queued_generation != generation or queued_index != index:
+            return
+        self._queued_search = None
+        if not ready:
+            return
+        safe_single_shot(0, lambda kw=keyword: self.gui.start_and_search(keyword=kw))
+
+    def _clear_queued_search(self, index: int, generation: int):
+        queued_search = self._queued_search
+        if queued_search is None:
+            return
+        queued_generation, queued_index, _keyword = queued_search
+        if queued_generation == generation and queued_index == index:
+            self._queued_search = None
+
+    def _clear_active_preprocess(self, index: int, generation: int):
+        if self._active_preprocess == (index, generation):
+            self._active_preprocess = None

--- a/GUI/manager/preprocess.py
+++ b/GUI/manager/preprocess.py
@@ -1,5 +1,3 @@
-import asyncio
-import httpx
 from PySide6.QtCore import Qt, QObject
 from qfluentwidgets import InfoBar, InfoBarPosition
 
@@ -11,11 +9,8 @@ from GUI.uic.qfluent.components import CustomInfoBar
 from utils import conf
 from utils.website.contracts import PreprocessResult
 from utils.website.site_runtime import GuiSiteRuntime
-from utils.website.preprocess import run_site_preprocess
+from utils.website.preprocess import run_script_preprocess
 from variables import SPIDERS, VER, Spider
-
-
-data_cli: httpx.AsyncClient | None = None
 
 
 class PreprocessManager(QObject):
@@ -33,19 +28,8 @@ class PreprocessManager(QObject):
         self.task_manager.cancel_all_tasks()
         return self._switch_generation
 
-    def _reset_data_cli(self, proxies: list[str]):
-        global data_cli
-        if data_cli is not None:
-            asyncio.run(data_cli.aclose())
-        transport = dict(proxy=f"http://{proxies[0]}", retries=2) if proxies else dict(retries=2)
-        data_cli = httpx.AsyncClient(transport=httpx.AsyncHTTPTransport(**transport))
-
     def handle_choosebox_changed(self, index: int, gui_site_runtime: GuiSiteRuntime | None):
         generation = self._next_generation()
-        proxies = ()
-        if gui_site_runtime is not None:
-            proxies = gui_site_runtime.runtime_context.transport.proxies
-        self._reset_data_cli(list(proxies))
         self._active_preprocess = (index, generation)
         self._queued_search = None
         self._sync_preview_runtime(index, gui_site_runtime, runtime_ready=False)
@@ -63,16 +47,13 @@ class PreprocessManager(QObject):
         self.gui.preview_mgr.handle_choosebox_changed(index, gui_site_runtime)
 
     def _start_preprocess(self, index: int, generation: int):
-        current_data_client = data_cli
-
         def task(progress_callback=None):
             if index == 7:
-                return run_site_preprocess(index, gui_site_runtime=None, conf_state=conf, data_client=current_data_client,
-                    progress_callback=progress_callback)
+                return run_script_preprocess(conf_state=conf, progress_callback=progress_callback)
             gui_site_runtime = self.gui.gui_site_runtime
             if gui_site_runtime is None:
                 raise RuntimeError("gui_site_runtime unavailable for preprocess flow")
-            return gui_site_runtime.preprocess(conf_state=conf, data_client=current_data_client, progress_callback=progress_callback)
+            return gui_site_runtime.preprocess(conf_state=conf, progress_callback=progress_callback)
 
         site_name = "Script" if index == 7 else SPIDERS.get(index, str(index))
         self.task_manager.execute_simple_task(
@@ -100,11 +81,7 @@ class PreprocessManager(QObject):
             for action in result.actions:
                 self._apply_action(action)
 
-            self._dispatch_queued_search(
-                index,
-                generation,
-                ready=bool(result.runtime_ready and not result.block_search),
-            )
+            self._dispatch_queued_search(index, generation, ready=bool(result.runtime_ready and not result.block_search))
         finally:
             self._clear_active_preprocess(index, generation)
 
@@ -179,10 +156,7 @@ class PreprocessManager(QObject):
         self.gui.aggrBtn.setVisible(True)
 
     def sync_gui_site_runtime(self, gui_site_runtime: GuiSiteRuntime | None):
-        proxies = ()
-        if gui_site_runtime is not None:
-            proxies = gui_site_runtime.runtime_context.transport.proxies
-        self._reset_data_cli(list(proxies))
+        _ = gui_site_runtime
 
     def queue_search_after_preprocess(self, index: int, keyword: str) -> bool:
         active_preprocess = self._active_preprocess
@@ -195,14 +169,10 @@ class PreprocessManager(QObject):
         return True
 
     def cleanup(self):
-        global data_cli
         self._next_generation()
         self._active_preprocess = None
         self._queued_search = None
         self.task_manager.reset()
-        if data_cli is not None:
-            asyncio.run(data_cli.aclose())
-            data_cli = None
 
     def _refresh_runtime_domain(self, index: int, domain: str | None):
         if not domain:

--- a/GUI/manager/preview/__init__.py
+++ b/GUI/manager/preview/__init__.py
@@ -108,6 +108,16 @@ class PreviewMgr:
                 self.gui._destroy_browser_window()
         self.gui.refresh_lifecycle_state()
 
+    def replace_gui_site_runtime(self, gui_site_runtime: GuiSiteRuntime | None):
+        self._generation += 1
+        self.gui_site_runtime = gui_site_runtime
+        if self.site_index in SPIDERS and gui_site_runtime is not None:
+            self.create_worker(gui_site_runtime)
+            self.gui.refresh_lifecycle_state()
+            return
+        self._stop_worker()
+        self.gui.refresh_lifecycle_state()
+
     def begin_preview_session(self):
         self._session_id += 1
         self._reset_page_state()

--- a/GUI/script/kemono/__init__.py
+++ b/GUI/script/kemono/__init__.py
@@ -1,7 +1,6 @@
 import sys
 import subprocess
 import pathlib as p
-import pickle
 import typing as t
 from datetime import datetime
 
@@ -23,8 +22,9 @@ from qframelesswindow import FramelessWindow
 from variables import CGS_DOC
 from deploy import curr_os
 from utils import ori_path, temp_p
-from utils.script.image.kemono import kemono_topic, conf, KemonoAuthor
+from utils.script.image.kemono import kemono_topic, conf
 from utils.config.qc import kemono_cfg
+from utils.website.kemono.db import KemonoAuthor, load_kemono_authors
 from GUI.core.font import font_color
 from GUI.uic.qfluent.components import TextBrowserWithBg, BgMgr, CustomFlyout
 from GUI.manager.async_task import AsyncTaskManager, TaskConfig
@@ -711,8 +711,7 @@ class KemonoInterface(QFrame):
         self.table_window.show()
 
     def _set_kemono_table(self):
-        with open(temp_p.joinpath("kemono_data.pkl"), 'rb') as f:
-            data = pickle.load(f)
+        data = load_kemono_authors(temp_p.joinpath("kemono.db"))
         self.table_window = KemonoTableView(data, self)
         self.table_window.closeBtn.clicked.connect(self.table_window.close)
         self.table_window.closed.connect(self.table_window.hide)

--- a/GUI/thread/preview.py
+++ b/GUI/thread/preview.py
@@ -79,6 +79,12 @@ class PreviewWorker(QThread):
                 _ = CoverTask
         self._task_queue.put(_(*args, **kw))
 
+    async def _do_search(self, keyword, site_index, page=1):
+        return await self.thread_site_runtime.preview_search(keyword, page=page)
+
+    async def _do_fetch_episodes(self, book, site_index):
+        return await self.thread_site_runtime.preview_fetch_episodes(book)
+
     async def _do_fetch_episodes_batch(self, items):
         semaphore = asyncio.Semaphore(self.thread_site_runtime.preview_batch_limit("episodes", 4))
 
@@ -127,13 +133,13 @@ class PreviewWorker(QThread):
                 match task:
                     case SearchTask(keyword=kw, page=pg):
                         try:
-                            books = self._loop.run_until_complete(self.thread_site_runtime.preview_search(kw, page=pg))
+                            books = self._loop.run_until_complete(self._do_search(kw, self.site_index, page=pg))
                         except Exception as exc:
                             self.search_error.emit(f"{exc}")
                         else:
                             self.search_done.emit(self._generation, kw, self.site_index, books)
                     case EpisodesTask(session_id=sid, book_key=bk, book=b):
-                        episodes = self._loop.run_until_complete(self.thread_site_runtime.preview_fetch_episodes(b))
+                        episodes = self._loop.run_until_complete(self._do_fetch_episodes(b, self.site_index))
                         self.episodes_done.emit(self._generation, sid, bk, episodes)
                     case EpisodesBatchTask(items=its):
                         self._loop.run_until_complete(self._do_fetch_episodes_batch(its))

--- a/GUI/tools/hitomi_tool.py
+++ b/GUI/tools/hitomi_tool.py
@@ -18,7 +18,7 @@ from assets import res
 from variables import DEFAULT_COMPLETER
 from utils import ori_path, conf
 
-hitomi_db_path = ori_path.joinpath("assets/hitomi.db")
+hitomi_db_path = ori_path.joinpath("__temp/hitomi.db")
 
 
 class CustomComboBox(QComboBox):
@@ -48,7 +48,7 @@ class HitomiTools(QWidget):
         self.output_type = ''
         self.output_mgr = self.OutputMgr(self)
         self.tmp_map = {}
-        self.conn = sqlite3.connect(ori_path.joinpath('assets/hitomi.db'))
+        self.conn = sqlite3.connect(hitomi_db_path)
         self.init_ui()
         self.set_dataset()
         self.update_entries()  # Initial update

--- a/utils/script/image/kemono.py
+++ b/utils/script/image/kemono.py
@@ -8,7 +8,6 @@ import os
 import sys
 import shutil
 import asyncio
-import pickle
 import pathlib as p
 from dataclasses import dataclass, asdict
 
@@ -26,10 +25,12 @@ from utils.network.doh import build_http_transport, dns_stub_server
 from utils.script import conf as script_conf, AioRClient, BlackList, folder_sub
 from utils.script.motrix import MotrixRPC, build_motrix_dns_options
 from utils.script.image.expander import FilterMgr, format_naming
+from utils.website.kemono.db import load_kemono_authors
 
 conf = script_conf
 temp_p = proj_p.joinpath("__temp")
 temp_p.mkdir(parents=True, exist_ok=True)
+kemono_db_path = temp_p.joinpath("kemono.db")
 
 
 kemono_topic = """
@@ -43,19 +44,6 @@ headers = {
     "Accept-Language": "zh-CN,zh;q=0.8,zh-TW;q=0.7,zh-HK;q=0.5,en-US;q=0.3,en;q=0.2",
     'Accept': 'text/css',
 }
-
-
-@dataclass
-class KemonoAuthor:
-    id: str
-    name: str
-    service: str
-    updated: int
-    favorited: int
-    
-    @property
-    def avatar(self):
-        return f"https://img.{domain}/icons/{self.service}/{self.id}"
 
 
 class OverSizeErr(Exception):
@@ -205,7 +193,7 @@ class Kemono:
         )
 
     class Creator:
-        cache_path = temp_p.joinpath("kemono_data.pkl")
+        db_path = kemono_db_path
         
         def __init__(self, parent, **ckw):
             self.k = parent
@@ -342,12 +330,7 @@ class Kemono:
         @logger.catch
         async def by_creatorid(self, order_creatorids=None):
             order_creatorids = set(map(str, order_creatorids))
-            all_creators = None
-            if self.cache_path.exists():
-                with open(self.cache_path, 'rb') as f:
-                    all_creators = pickle.load(f)
-            else:
-                all_creators = await self._download_and_cache_kemono_data()
+            all_creators = await asyncio.to_thread(load_kemono_authors, self.db_path)
 
             found_ids = set()
             for creator_id in order_creatorids:
@@ -359,47 +342,6 @@ class Kemono:
             not_found = order_creatorids - found_ids
             if not_found:
                 logger.warning(f"not found creatorid: {not_found}")
-
-        async def _download_and_cache_kemono_data(self):
-            """下载kemono创作者数据并转换为KemonoAuthor映射字典"""
-            creators_txt = temp_p.joinpath("creators.txt")
-            if not creators_txt.exists():
-                _data = [[Api.creators_txt], {"dir": str(temp_p), **self.k.motrix_add_uri_options()}]
-                resp = await self.k.rpc.sess.request(
-                    "POST", self.k.rpc.url, headers={"Content-Type": "application/json"},
-                    json=MotrixRPC.format_data(_data, _id="creators.txt"))
-                add_result = resp.json()
-                gid = add_result.get('result')
-                
-                run_flag = True
-                while run_flag:
-                    status_tasks = [self.k.rpc.check_gid_status(gid)]
-                    results = await asyncio.gather(*status_tasks)
-                    for gid, result in results:
-                        if 'error' in result:
-                            result = {'result': {'status': 'error'}}
-                        status = result.get('result', {}).get('status')
-                        if status == 'complete':
-                            run_flag = False
-                        elif status == 'error':
-                            raise ValueError(f"""Download creators.txt failed,\n
-                                you can download it from {Api.creators_txt},\n
-                            then put it into {creators_txt}""")
-                    await asyncio.sleep(1.5)
-            with open(creators_txt, 'r', encoding='utf-8') as f:
-                json_data = json.load(f)
-            author_dict = {}
-            for item in json_data:
-                author_id = item['id']
-                author = KemonoAuthor(
-                    id=author_id, name=item['name'], service=item['service'],
-                    updated=item['updated'], favorited=item['favorited']
-                )
-                author_dict[author_id] = author
-            with open(self.cache_path, 'wb') as f:
-                pickle.dump(author_dict, f)
-
-            return author_dict
 
     def run_filter(self, u_s, p_t, _task) -> bool:
         """

--- a/utils/website/core/__init__.py
+++ b/utils/website/core/__init__.py
@@ -43,6 +43,24 @@ class Cache:
         self.cache_f = cache_f
         self.flag = None
         self.val = None
+        self.state = None
+
+    @staticmethod
+    def _is_expired(cache_path, expiry_time: t.Union[int, datetime, str, callable]) -> bool:
+        now = datetime.now()
+        today_start = now.replace(hour=0, minute=0, second=0, microsecond=0)
+        file_time = datetime.fromtimestamp(cache_path.stat().st_mtime)
+        match expiry_time:
+            case int():
+                return now - file_time > timedelta(hours=expiry_time)
+            case datetime():
+                return now > expiry_time
+            case str() if expiry_time == "daily":
+                return file_time < today_start
+            case _ if callable(expiry_time):
+                dynamic_expiry = expiry_time()
+                return now > dynamic_expiry
+        return True
 
     def with_expiry(self, expiry_time: t.Union[int, datetime, str, callable]=168, write_in=False):
         """缓存有效期装饰器
@@ -61,6 +79,8 @@ class Cache:
                     if cache_path.suffix == '.pkl':
                         with open(cache_path, 'rb') as f:
                             cached_data = pickle.load(f)
+                    elif cache_path.suffix in {'.db', '.sqlite', '.sqlite3'}:
+                        cached_data = cache_path
                     else:
                         with open(cache_path, 'r', encoding='utf-8') as f:
                             cached_data = f.read().strip()
@@ -68,11 +88,13 @@ class Cache:
                     if cached_data:
                         self.flag = "validate"
                         self.val = cached_data
+                        self.state = "validate"
                         return cached_data
                     else:
                         os.remove(cache_path)
 
                 result = func(*args, **kwargs)
+                self.state = "expired" if cache_exists_flag else "missing"
                 if result is not None and write_in:
                     if cache_path.exists():
                         os.remove(cache_path)  # remark: 解决相同内容写入却不更新最后访问时间导致的缓存失效恶性循环
@@ -82,7 +104,10 @@ class Cache:
                     else:
                         with open(cache_path, 'w', encoding='utf-8') as f:
                             f.write(str(result))
-                self.flag = "new"
+                    self.flag = "new"
+                    self.state = "new"
+                else:
+                    self.flag = "new"
                 self.val = result
                 return result
             return wrapper
@@ -93,20 +118,7 @@ class Cache:
         if not cache_exists_flag:
             return decorator
 
-        # 计算过期标志
-        now = datetime.now()
-        today_start = now.replace(hour=0, minute=0, second=0, microsecond=0)
-        file_time = datetime.fromtimestamp(cache_path.stat().st_mtime)
-        match expiry_time:
-            case int():
-                expiry_flag = now - file_time > timedelta(hours=expiry_time)
-            case datetime():
-                expiry_flag = now > expiry_time
-            case str() if expiry_time == "daily":
-                expiry_flag = file_time < today_start
-            case _ if callable(expiry_time):
-                dynamic_expiry = expiry_time()
-                expiry_flag = now > dynamic_expiry
+        expiry_flag = self._is_expired(cache_path, expiry_time)
         return decorator
 
     def run(self, func, expiry_time=168, write_in=False):

--- a/utils/website/hitomi/scape_dataset.py
+++ b/utils/website/hitomi/scape_dataset.py
@@ -10,9 +10,9 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 
 import httpx
 from lxml import html
-
+# TODO[0](2026-05-05): ratelimit
 from assets import res
-from utils import ori_path, temp_p, conf
+from utils import temp_p, conf
 
 
 BASE_URL = "https://hitomi.la/all{category}-{letter}.html"
@@ -39,10 +39,11 @@ def _get_paths(db_path_override=None):
     if db_path_override:
         p = Path(db_path_override)
         p.parent.mkdir(parents=True, exist_ok=True)
-        tmp = p.parent / '__temp'
-        tmp.mkdir(exist_ok=True)
+        tmp = p.parent / 'hitomi'
+        tmp.mkdir(parents=True, exist_ok=True)
         return p, tmp
-    return ori_path.joinpath('assets/hitomi.db'), temp_p
+    db_path = temp_p.joinpath('hitomi.db')
+    return db_path
 
 
 def _get_proxy():
@@ -129,9 +130,9 @@ def _save_one(db_conn, table_name, items, rewrite_flag):
         print(f"[SUCCESS] {table_name} written {cursor.rowcount}")
 
 
-def scrape_and_save(db_p, temp_p, workers=2, max_retries=3, timeout=10):
+def scrape_and_save(db_p, workers=2, max_retries=3, timeout=10):
     client = _make_client(_get_proxy())
-    init_err_f = temp_p.joinpath('hitomi_db_init_err.json') if hasattr(temp_p, 'joinpath') else Path(temp_p) / 'hitomi_db_init_err.json'
+    init_err_f = temp_p.joinpath('hitomi_db_init_err.json')
     tb_rewrite_flag = False
     tasks = []
 
@@ -186,14 +187,10 @@ def main():
     parser.add_argument('--db-path', type=str, default=None, help='override hitomi.db path (for CI)')
     args = parser.parse_args()
 
-    db_p, temp_p = _get_paths(args.db_path)
-
+    db_p = _get_paths(args.db_path)
     Db.create_tables(db_p)
     success = scrape_and_save(
-        db_p, temp_p,
-        workers=args.workers,
-        max_retries=args.max_retries,
-        timeout=args.timeout,
+        db_p, workers=args.workers, max_retries=args.max_retries, timeout=args.timeout,
     )
     exit(0 if success else 1)
 

--- a/utils/website/info.py
+++ b/utils/website/info.py
@@ -178,3 +178,17 @@ class HitomiBookInfo(Ero):
 
 class HComicBookInfo(Ero):
     source = "h_comic"
+
+
+class NhentaiBookInfo(Ero):
+    source = "nhentai"
+    media_id: str = None
+    lang: str = None
+    english_title: str = None
+    japanese_title: str = None
+    pretty_title: str = None
+    pics: list = []
+
+    @property
+    def say(self):
+        return str(self.idx), self.lang or "-", self.pages, self.name, chr(12288)

--- a/utils/website/ins.py
+++ b/utils/website/ins.py
@@ -9,9 +9,9 @@ from .site_runtime import ProviderDescriptor
 
 provider_map = {
     1: KaobeiUtils, 2: JmUtils, 3: WnacgUtils, 4: EHentaiKits, 5: MangabzUtils,
-    6: HitomiUtils, 8: HComicUtils, 9: JestfulUtils,
+    6: HitomiUtils, 8: HComicUtils, 9: JestfulUtils, 10: NhentaiUtils,
     'manga_copy': KaobeiUtils, 'kaobei': KaobeiUtils, 'jm': JmUtils, 'wnacg': WnacgUtils, 'ehentai': EHentaiKits, 'mangabz': MangabzUtils,
-    'hitomi': HitomiUtils, 'h_comic': HComicUtils, 'jestful': JestfulUtils, 'jf': JestfulUtils
+    'hitomi': HitomiUtils, 'h_comic': HComicUtils, 'jestful': JestfulUtils, 'jf': JestfulUtils, 'nhentai': NhentaiUtils
 }
 
 

--- a/utils/website/kemono/db.py
+++ b/utils/website/kemono/db.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from contextlib import closing
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True, slots=True)
+class KemonoAuthor:
+    id: str
+    name: str
+    service: str
+    updated: int
+    favorited: int
+
+    @property
+    def avatar(self) -> str:
+        return f"https://img.kemono.cr/icons/{self.service}/{self.id}"
+
+    def to_payload(self) -> dict[str, str | int]:
+        return asdict(self)
+
+
+def _normalize_author(item: dict) -> KemonoAuthor:
+    if not isinstance(item, dict):
+        raise TypeError(f"invalid kemono creator row: {item!r}")
+    return KemonoAuthor(
+        id=str(item["id"]),
+        name=str(item["name"]),
+        service=str(item["service"]),
+        updated=int(item["updated"]),
+        favorited=int(item["favorited"]),
+    )
+
+
+class KemonoAuthorsDb:
+    def __init__(self, db_path: Path):
+        self.db_path = Path(db_path)
+
+    def ensure_schema(self) -> None:
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        with closing(sqlite3.connect(self.db_path)) as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                """
+                CREATE TABLE IF NOT EXISTS authors (
+                    id TEXT PRIMARY KEY,
+                    name TEXT NOT NULL,
+                    service TEXT NOT NULL,
+                    updated INTEGER NOT NULL,
+                    favorited INTEGER NOT NULL
+                )
+                """
+            )
+            cursor.execute("CREATE INDEX IF NOT EXISTS idx_authors_service ON authors(service)")
+            cursor.execute("CREATE INDEX IF NOT EXISTS idx_authors_favorited ON authors(favorited DESC)")
+            conn.commit()
+
+    def replace_from_creators(self, creators: list[dict]) -> int:
+        self.ensure_schema()
+        authors = [_normalize_author(item) for item in creators]
+        with closing(sqlite3.connect(self.db_path)) as conn:
+            cursor = conn.cursor()
+            cursor.executemany(
+                """
+                INSERT INTO authors (id, name, service, updated, favorited)
+                VALUES (?, ?, ?, ?, ?)
+                ON CONFLICT(id) DO UPDATE SET
+                    name=excluded.name,
+                    service=excluded.service,
+                    updated=excluded.updated,
+                    favorited=excluded.favorited
+                """,
+                [(author.id, author.name, author.service, author.updated, author.favorited) for author in authors],
+            )
+            conn.commit()
+        return len(authors)
+
+    def load_all(self) -> dict[str, KemonoAuthor]:
+        if not self.db_path.exists():
+            raise FileNotFoundError(f"kemono db not found: {self.db_path}")
+        with closing(sqlite3.connect(self.db_path)) as conn:
+            cursor = conn.cursor()
+            cursor.execute("SELECT id, name, service, updated, favorited FROM authors")
+            rows = cursor.fetchall()
+        return {
+            str(row_id): KemonoAuthor(
+                id=str(row_id),
+                name=str(name),
+                service=str(service),
+                updated=int(updated),
+                favorited=int(favorited),
+            )
+            for row_id, name, service, updated, favorited in rows
+        }
+
+
+def build_kemono_db_from_creators_bytes(db_path: Path, payload: bytes) -> int:
+    data = json.loads(payload.decode("utf-8"))
+    return KemonoAuthorsDb(db_path).replace_from_creators(data)
+
+
+def load_kemono_authors(db_path: Path) -> dict[str, KemonoAuthor]:
+    return KemonoAuthorsDb(db_path).load_all()

--- a/utils/website/kemono/gen_assets.py
+++ b/utils/website/kemono/gen_assets.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import asyncio
+
+import httpx
+
+from assets import res
+from utils import temp_p
+from utils.website.kemono.db import build_kemono_db_from_creators_bytes
+
+
+KEMONO_CREATORS_API_URL = "https://kemono.cr/api/v1/creators"
+HEADERS = {
+    "accept": "application/json",
+    "accept-language": res.Vars.ua_accept_language,
+    "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:150.0) Gecko/20100101 Firefox/150.0",
+    "referer": "https://kemono.cr/",
+}
+
+
+def _build_data_client() -> httpx.AsyncClient:
+    kwargs = {"headers": HEADERS, "http2": True, "follow_redirects": True}
+    kwargs["proxy"] = "http://127.0.0.1:10809"
+    return httpx.AsyncClient(**kwargs)
+
+
+async def fetch_kemono_creators_payload(*, data_client: httpx.AsyncClient, timeout: float = 60) -> bytes:
+    resp = await data_client.get(KEMONO_CREATORS_API_URL, timeout=timeout)
+    resp.raise_for_status()
+    return resp.content
+
+
+async def generate_kemono_db():
+    resolved_db_path = temp_p.joinpath("kemono.db")
+    resolved_db_path.parent.mkdir(parents=True, exist_ok=True)
+    with _build_data_client() as data_client:
+        payload = await fetch_kemono_creators_payload(data_client=data_client)
+    return await asyncio.to_thread(build_kemono_db_from_creators_bytes, resolved_db_path, payload)
+
+
+def main():
+    written = asyncio.run(generate_kemono_db())
+    print(f"[DONE] kemono db rows affected {written}")
+
+
+if __name__ == "__main__":
+    main()

--- a/utils/website/nhentai/__init__.py
+++ b/utils/website/nhentai/__init__.py
@@ -17,7 +17,50 @@ class NhentaiParseError(ValueError):
     pass
 
 
+class NhentaiTagCatalog:
+    _tag_types = ("language", "category", "artist")
+
+    def __init__(self):
+        self.reset()
+
+    def reset(self):
+        self.loaded = False
+        self.db_path = None
+        self.by_type = {tag_type: {} for tag_type in self._tag_types}
+        self.valid_ids_by_type = {tag_type: set() for tag_type in self._tag_types}
+
+    def load(self, db_path: str | Path | None = None, *, default_db_path: str | Path, excluded_language_names: set[str]) -> dict[str, int]:
+        resolved_db_path = Path(db_path) if db_path is not None else Path(default_db_path)
+        if not resolved_db_path.exists():
+            raise NhentaiParseError(f"nhentai tag db not found: {resolved_db_path}")
+        with closing(sqlite3.connect(resolved_db_path)) as conn:
+            rows = conn.execute("SELECT id, name, type FROM tags WHERE type IN ('language', 'category', 'artist')").fetchall()
+        catalog = {tag_type: {} for tag_type in self._tag_types}
+        for tag_id, name, tag_type in rows:
+            if tag_type in catalog:
+                catalog[tag_type][int(tag_id)] = str(name)
+        valid_ids_by_type = {
+            tag_type: {
+                tag_id for tag_id, tag_name in mapping.items()
+                if tag_type != "language" or tag_name not in excluded_language_names
+            }
+            for tag_type, mapping in catalog.items()
+        }
+        self.by_type = catalog
+        self.valid_ids_by_type = valid_ids_by_type
+        self.db_path = resolved_db_path
+        self.loaded = True
+        return {tag_type: len(mapping) for tag_type, mapping in catalog.items()}
+
+    def preload(self, db_path: str | Path | None = None, *, default_db_path: str | Path, excluded_language_names: set[str]) -> dict[str, int]:
+        return self.load(db_path=db_path, default_db_path=default_db_path, excluded_language_names=excluded_language_names)
+
+
+NHENTAI_TAG_CATALOG = NhentaiTagCatalog()
+
+
 class _NhentaiContract:
+    _language_excluded_names = {"translated"}
     name = "nhentai"
     proxy_policy = "proxy"
     domain = "nhentai.net"
@@ -47,9 +90,6 @@ class _NhentaiContract:
     tag_db_path = ori_path.joinpath("__temp/nhentai.db")
     gallery_url_template = f"{index}g/%s/"
     gallery_api_url_template = f"{api_index}/galleries/%s?include=comments%%2Crelated"
-    _tag_catalog_loaded = False
-    _tag_catalog_db_path = None
-    _tag_catalog_by_type = {"language": {}, "category": {}, "artist": {}}
 
     @classmethod
     def build_search_url(cls, keyword: str, *, page: int = 1, sort: str = "date") -> str:
@@ -63,55 +103,10 @@ class _NhentaiContract:
             headers["Referer"] = referer
         return headers
 
-    @classmethod
-    def _tag_catalog_owner(cls):
-        return _NhentaiContract
-
-    @classmethod
-    def reset_tag_catalog(cls):
-        owner = cls._tag_catalog_owner()
-        owner._tag_catalog_loaded = False
-        owner._tag_catalog_db_path = None
-        owner._tag_catalog_by_type = {"language": {}, "category": {}, "artist": {}}
-
-    @classmethod
-    def load_tag_catalog(cls, db_path: str | Path | None = None) -> dict[str, int]:
-        owner = cls._tag_catalog_owner()
-        resolved_db_path = Path(db_path) if db_path is not None else Path(owner.tag_db_path)
-        if not resolved_db_path.exists():
-            raise NhentaiParseError(f"nhentai tag db not found: {resolved_db_path}")
-        with closing(sqlite3.connect(resolved_db_path)) as conn:
-            rows = conn.execute("SELECT id, name, type FROM tags WHERE type IN ('language', 'category', 'artist')").fetchall()
-        catalog = {"language": {}, "category": {}, "artist": {}}
-        for tag_id, name, tag_type in rows:
-            if tag_type in catalog:
-                catalog[tag_type][int(tag_id)] = str(name)
-        owner._tag_catalog_by_type = catalog
-        owner._tag_catalog_db_path = resolved_db_path
-        owner._tag_catalog_loaded = True
-        return {tag_type: len(mapping) for tag_type, mapping in catalog.items()}
-
-    @classmethod
-    def ensure_tag_catalog_loaded(cls) -> dict[str, dict[int, str]]:
-        owner = cls._tag_catalog_owner()
-        if not owner._tag_catalog_loaded:
-            cls.load_tag_catalog()
-        return owner._tag_catalog_by_type
-
-    @classmethod
-    def preload_tag_catalog(cls, db_path: str | Path | None = None) -> dict[str, int]:
-        return cls.load_tag_catalog(db_path=db_path)
-
-    @classmethod
-    def tag_catalog(cls) -> dict[str, dict[int, str]]:
-        return cls.ensure_tag_catalog_loaded()
-
-    @classmethod
-    def tag_name_by_type(cls, tag_type: str) -> dict[int, str]:
-        return cls.ensure_tag_catalog_loaded().get(str(tag_type), {})
-
 
 class NhentaiParser(_NhentaiContract):
+    catalog: NhentaiTagCatalog = NHENTAI_TAG_CATALOG
+
     @classmethod
     def _json_payload(cls, resp_text):
         try:
@@ -157,32 +152,22 @@ class NhentaiParser(_NhentaiContract):
     def _tag_name_from_ids(cls, tag_ids: list[int], tag_type: str, *, excluded_names: set[str] | None = None) -> str | None:
         if not tag_ids:
             return None
-        catalog = cls.ensure_tag_catalog_loaded()
-        mapping = catalog.get(tag_type, {})
+        mapping = cls.catalog.by_type.get(tag_type, {})
+        valid_ids = cls.catalog.valid_ids_by_type.get(tag_type, set())
         excluded = excluded_names or set()
         for tag_id in tag_ids:
-            name = mapping.get(int(tag_id))
-            if name is not None and name not in excluded:
+            resolved_tag_id = int(tag_id)
+            if resolved_tag_id not in valid_ids:
+                continue
+            name = mapping[resolved_tag_id]
+            if name not in excluded:
                 return name
         return None
-
-    @classmethod
-    def _language_from_tag_ids(cls, tag_ids: list[int]) -> str | None:
-        return cls._tag_name_from_ids(tag_ids, "language", excluded_names={"translated"})
-
-    @classmethod
-    def _category_from_tag_ids(cls, tag_ids: list[int]) -> str | None:
-        return cls._tag_name_from_ids(tag_ids, "category")
-
-    @classmethod
-    def _artist_from_tag_ids(cls, tag_ids: list[int]) -> str | None:
-        return cls._tag_name_from_ids(tag_ids, "artist")
 
     @classmethod
     def parse_search_item(cls, target: dict):
         if not isinstance(target, dict):
             raise NhentaiParseError("nhentai 搜索条目不是对象")
-        cls.ensure_tag_catalog_loaded()
         gallery_id = str(cls._required(target, "id"))
         media_id = str(cls._required(target, "media_id"))
         tag_ids = target.get("tag_ids") or []
@@ -195,8 +180,8 @@ class NhentaiParser(_NhentaiContract):
             id=gallery_id, media_id=media_id, name=cls._select_title(english_title=english_title, japanese_title=japanese_title),
             english_title=english_title, japanese_title=japanese_title, preview_url=cls.gallery_url_template % gallery_id,
             url=cls.gallery_api_url_template % gallery_id, pages=int(cls._required(target, "num_pages")),
-            img_preview=cls.build_thumbnail_url(thumbnail), lang=cls._language_from_tag_ids(tag_ids),
-            btype=cls._category_from_tag_ids(tag_ids),
+            img_preview=cls.build_thumbnail_url(thumbnail), lang=cls._tag_name_from_ids(tag_ids, "language"),
+            btype=cls._tag_name_from_ids(tag_ids, "category"),
         )
 
     @classmethod
@@ -205,7 +190,6 @@ class NhentaiParser(_NhentaiContract):
         targets = payload.get("result")
         if not isinstance(targets, list):
             raise NhentaiParseError("nhentai 搜索 API 缺少 result 列表")
-        cls.ensure_tag_catalog_loaded()
         return [cls.parse_search_item(target) for target in targets]
 
     @classmethod
@@ -233,24 +217,27 @@ class NhentaiParser(_NhentaiContract):
         tags = payload.get("tags") or []
         if not isinstance(tags, list):
             raise NhentaiParseError("nhentai gallery detail tags 不是列表")
-        cls.ensure_tag_catalog_loaded()
         pics = cls._parse_page_assets(payload.get("pages"), media_id=media_id)
         thumbnail_path = (payload.get("thumbnail") or {}).get("path")
         cover_path = (payload.get("cover") or {}).get("path")
         english_title = title.get("english")
         japanese_title = title.get("japanese")
         pretty_title = title.get("pretty")
-        language_tag_ids = [tag["id"] for tag in tags if tag.get("type") == "language" and tag.get("id")]
-        category_tag_ids = [tag["id"] for tag in tags if tag.get("type") == "category" and tag.get("id")]
-        artist_tag_ids = [tag["id"] for tag in tags if tag.get("type") == "artist" and tag.get("id")]
+        tag_ids_by_type = {"language": [], "category": [], "artist": []}
+        for tag in tags:
+            tag_type = tag.get("type")
+            tag_id = tag.get("id")
+            if tag_type in tag_ids_by_type and tag_id:
+                tag_ids_by_type[tag_type].append(tag_id)
         return NhentaiBookInfo(
             id=gallery_id, media_id=media_id,
             name=cls._select_title(english_title=english_title, japanese_title=japanese_title, pretty_title=pretty_title),
             english_title=english_title, japanese_title=japanese_title, pretty_title=pretty_title,
             preview_url=cls.gallery_url_template % gallery_id, url=cls.gallery_api_url_template % gallery_id,
             pages=int(cls._required(payload, "num_pages")), img_preview=cls.build_thumbnail_url(thumbnail_path or cover_path),
-            lang=cls._language_from_tag_ids(language_tag_ids), artist=cls._artist_from_tag_ids(artist_tag_ids),
-            btype=cls._category_from_tag_ids(category_tag_ids),
+            lang=cls._tag_name_from_ids(tag_ids_by_type["language"], "language"),
+            artist=cls._tag_name_from_ids(tag_ids_by_type["artist"], "artist"),
+            btype=cls._tag_name_from_ids(tag_ids_by_type["category"], "category"),
             tags=[tag.get("name") for tag in tags if tag.get("type") != "language" and tag.get("name")], pics=pics,
         )
 
@@ -341,11 +328,24 @@ class NhentaiUtils(_NhentaiContract, EroUtils, Cookies, Previewer):
     parser = NhentaiParser
     reqer_cls = NhentaiReqer
     browser_referer_mode = "provider_index"
+    catalog = NHENTAI_TAG_CATALOG
 
     def __init__(self, _conf):
         self.reqer = self.reqer_cls(_conf)
         self.parser = self.__class__.parser
-        self.ensure_tag_catalog_loaded()
+        self.parser.catalog = self.catalog
+
+    @classmethod
+    def reset_tag_catalog(cls):
+        cls.catalog.reset()
+
+    @classmethod
+    def load_tag_catalog(cls, db_path: str | Path | None = None) -> dict[str, int]:
+        return cls.catalog.load(db_path=db_path, default_db_path=cls.tag_db_path, excluded_language_names=cls._language_excluded_names)
+
+    @classmethod
+    def preload_tag_catalog(cls, db_path: str | Path | None = None) -> dict[str, int]:
+        return cls.catalog.preload(db_path=db_path, default_db_path=cls.tag_db_path, excluded_language_names=cls._language_excluded_names)
 
     @classmethod
     def preview_client_config(cls, **context):

--- a/utils/website/nhentai/__init__.py
+++ b/utils/website/nhentai/__init__.py
@@ -1,0 +1,352 @@
+import asyncio
+import json
+import re
+import sqlite3
+from contextlib import closing
+from pathlib import Path
+from urllib.parse import quote, urlencode
+
+import httpx
+
+from utils import ori_path
+from utils.website.core import Cookies, EroUtils, Previewer, Req
+from utils.website.info import NhentaiBookInfo
+
+
+class NhentaiParseError(ValueError):
+    pass
+
+
+class _NhentaiContract:
+    name = "nhentai"
+    proxy_policy = "proxy"
+    domain = "nhentai.net"
+    index = "https://nhentai.net/"
+    api_index = "https://nhentai.net/api/v2"
+    image_host = "https://i.nhentai.net"
+    thumbnail_host = "https://t.nhentai.net"
+    search_url_head = f"{api_index}/search?query="
+    turn_page_info = (r"page=\d+",)
+    mappings = {
+        "更新": f"{api_index}/galleries?page=1",
+    }
+    headers = {
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:150.0) Gecko/20100101 Firefox/150.0",
+        "Accept": "*/*",
+        "Accept-Language": "zh-CN,zh;q=0.9,zh-TW;q=0.8,zh-HK;q=0.7,en-US;q=0.6,en;q=0.5",
+    }
+    image_headers = {
+        "User-Agent": headers["User-Agent"],
+        "Accept": "image/avif,image/webp,image/png,image/svg+xml,image/*;q=0.8,*/*;q=0.5",
+        "Accept-Language": headers["Accept-Language"],
+    }
+    book_hea = headers
+    cookies_field = set()
+    uuid_regex = re.compile(r"(?:/g/|/api/v2/galleries/)(\d+)")
+    book_url_regex = r"^https://nhentai\.net/(?:g/\d+/?|api/v2/galleries/\d+(?:\?.*)?)"
+    tag_db_path = ori_path.joinpath("__temp/nhentai.db")
+    gallery_url_template = f"{index}g/%s/"
+    gallery_api_url_template = f"{api_index}/galleries/%s?include=comments%%2Crelated"
+    _tag_catalog_loaded = False
+    _tag_catalog_db_path = None
+    _tag_catalog_by_type = {"language": {}, "category": {}, "artist": {}}
+
+    @classmethod
+    def build_search_url(cls, keyword: str, *, page: int = 1, sort: str = "date") -> str:
+        query = urlencode({"query": keyword, "sort": sort, "page": max(1, int(page or 1))}, quote_via=quote)
+        return f"{cls.api_index}/search?{query}"
+
+    @classmethod
+    def with_referer(cls, referer: str | None = None) -> dict:
+        headers = dict(cls.headers)
+        if referer:
+            headers["Referer"] = referer
+        return headers
+
+    @classmethod
+    def _tag_catalog_owner(cls):
+        return _NhentaiContract
+
+    @classmethod
+    def reset_tag_catalog(cls):
+        owner = cls._tag_catalog_owner()
+        owner._tag_catalog_loaded = False
+        owner._tag_catalog_db_path = None
+        owner._tag_catalog_by_type = {"language": {}, "category": {}, "artist": {}}
+
+    @classmethod
+    def load_tag_catalog(cls, db_path: str | Path | None = None) -> dict[str, int]:
+        owner = cls._tag_catalog_owner()
+        resolved_db_path = Path(db_path) if db_path is not None else Path(owner.tag_db_path)
+        if not resolved_db_path.exists():
+            raise NhentaiParseError(f"nhentai tag db not found: {resolved_db_path}")
+        with closing(sqlite3.connect(resolved_db_path)) as conn:
+            rows = conn.execute("SELECT id, name, type FROM tags WHERE type IN ('language', 'category', 'artist')").fetchall()
+        catalog = {"language": {}, "category": {}, "artist": {}}
+        for tag_id, name, tag_type in rows:
+            if tag_type in catalog:
+                catalog[tag_type][int(tag_id)] = str(name)
+        owner._tag_catalog_by_type = catalog
+        owner._tag_catalog_db_path = resolved_db_path
+        owner._tag_catalog_loaded = True
+        return {tag_type: len(mapping) for tag_type, mapping in catalog.items()}
+
+    @classmethod
+    def ensure_tag_catalog_loaded(cls) -> dict[str, dict[int, str]]:
+        owner = cls._tag_catalog_owner()
+        if not owner._tag_catalog_loaded:
+            cls.load_tag_catalog()
+        return owner._tag_catalog_by_type
+
+    @classmethod
+    def preload_tag_catalog(cls, db_path: str | Path | None = None) -> dict[str, int]:
+        return cls.load_tag_catalog(db_path=db_path)
+
+    @classmethod
+    def tag_catalog(cls) -> dict[str, dict[int, str]]:
+        return cls.ensure_tag_catalog_loaded()
+
+    @classmethod
+    def tag_name_by_type(cls, tag_type: str) -> dict[int, str]:
+        return cls.ensure_tag_catalog_loaded().get(str(tag_type), {})
+
+
+class NhentaiParser(_NhentaiContract):
+    @classmethod
+    def _json_payload(cls, resp_text):
+        try:
+            payload = json.loads(resp_text)
+        except (TypeError, json.JSONDecodeError) as exc:
+            raise NhentaiParseError(f"nhentai JSON 解析失败: {exc}") from exc
+        if not isinstance(payload, dict):
+            raise NhentaiParseError("nhentai JSON 根节点不是对象")
+        return payload
+
+    @staticmethod
+    def _required(target: dict, key: str):
+        value = target.get(key)
+        if value is None or value == "":
+            raise NhentaiParseError(f"nhentai payload missing `{key}`")
+        return value
+
+    @classmethod
+    def _asset_url(cls, asset_path: str, *, host: str) -> str:
+        path = str(asset_path or "").strip()
+        if not path:
+            raise NhentaiParseError("nhentai asset path is empty")
+        if path.startswith("http://") or path.startswith("https://"):
+            return path
+        path = path.lstrip("/")
+        if not path.startswith("galleries/"):
+            raise NhentaiParseError(f"nhentai asset path must start with galleries/: {asset_path!r}")
+        return f"{host.rstrip('/')}/{path}"
+
+    @classmethod
+    def build_image_url(cls, asset_path: str) -> str:
+        return cls._asset_url(asset_path, host=cls.image_host)
+
+    @classmethod
+    def build_thumbnail_url(cls, asset_path: str | None) -> str | None:
+        return cls._asset_url(asset_path, host=cls.thumbnail_host) if asset_path else None
+
+    @staticmethod
+    def _select_title(*, english_title=None, japanese_title=None, pretty_title=None) -> str:
+        return japanese_title or pretty_title or english_title or "未知标题"
+
+    @classmethod
+    def _tag_name_from_ids(cls, tag_ids: list[int], tag_type: str, *, excluded_names: set[str] | None = None) -> str | None:
+        if not tag_ids:
+            return None
+        catalog = cls.ensure_tag_catalog_loaded()
+        mapping = catalog.get(tag_type, {})
+        excluded = excluded_names or set()
+        for tag_id in tag_ids:
+            name = mapping.get(int(tag_id))
+            if name is not None and name not in excluded:
+                return name
+        return None
+
+    @classmethod
+    def _language_from_tag_ids(cls, tag_ids: list[int]) -> str | None:
+        return cls._tag_name_from_ids(tag_ids, "language", excluded_names={"translated"})
+
+    @classmethod
+    def _category_from_tag_ids(cls, tag_ids: list[int]) -> str | None:
+        return cls._tag_name_from_ids(tag_ids, "category")
+
+    @classmethod
+    def _artist_from_tag_ids(cls, tag_ids: list[int]) -> str | None:
+        return cls._tag_name_from_ids(tag_ids, "artist")
+
+    @classmethod
+    def parse_search_item(cls, target: dict):
+        if not isinstance(target, dict):
+            raise NhentaiParseError("nhentai 搜索条目不是对象")
+        cls.ensure_tag_catalog_loaded()
+        gallery_id = str(cls._required(target, "id"))
+        media_id = str(cls._required(target, "media_id"))
+        tag_ids = target.get("tag_ids") or []
+        if not isinstance(tag_ids, list):
+            raise NhentaiParseError("nhentai search item tag_ids is not list")
+        english_title = target.get("english_title")
+        japanese_title = target.get("japanese_title")
+        thumbnail = target.get("thumbnail")
+        return NhentaiBookInfo(
+            id=gallery_id, media_id=media_id, name=cls._select_title(english_title=english_title, japanese_title=japanese_title),
+            english_title=english_title, japanese_title=japanese_title, preview_url=cls.gallery_url_template % gallery_id,
+            url=cls.gallery_api_url_template % gallery_id, pages=int(cls._required(target, "num_pages")),
+            img_preview=cls.build_thumbnail_url(thumbnail), lang=cls._language_from_tag_ids(tag_ids),
+            btype=cls._category_from_tag_ids(tag_ids),
+        )
+
+    @classmethod
+    def parse_search(cls, resp_text):
+        payload = cls._json_payload(resp_text)
+        targets = payload.get("result")
+        if not isinstance(targets, list):
+            raise NhentaiParseError("nhentai 搜索 API 缺少 result 列表")
+        cls.ensure_tag_catalog_loaded()
+        return [cls.parse_search_item(target) for target in targets]
+
+    @classmethod
+    def _parse_page_assets(cls, pages: list[dict], *, media_id: str) -> list[dict]:
+        if not isinstance(pages, list):
+            raise NhentaiParseError("nhentai gallery detail pages 不是列表")
+        pics = []
+        for idx, page in enumerate(pages, start=1):
+            if not isinstance(page, dict):
+                raise NhentaiParseError(f"nhentai gallery detail 第 {idx} 页不是对象")
+            path = str(cls._required(page, "path"))
+            if f"galleries/{media_id}/" not in path:
+                raise NhentaiParseError(f"nhentai page asset 与 media_id 不匹配: media_id={media_id} path={path}")
+            pics.append({"number": int(page.get("number") or idx), "path": path, "thumbnail": page.get("thumbnail")})
+        return pics
+
+    @classmethod
+    def parse_book(cls, resp_text):
+        payload = cls._json_payload(resp_text)
+        gallery_id = str(cls._required(payload, "id"))
+        media_id = str(cls._required(payload, "media_id"))
+        title = payload.get("title") or {}
+        if not isinstance(title, dict):
+            raise NhentaiParseError("nhentai gallery detail title 不是对象")
+        tags = payload.get("tags") or []
+        if not isinstance(tags, list):
+            raise NhentaiParseError("nhentai gallery detail tags 不是列表")
+        cls.ensure_tag_catalog_loaded()
+        pics = cls._parse_page_assets(payload.get("pages"), media_id=media_id)
+        thumbnail_path = (payload.get("thumbnail") or {}).get("path")
+        cover_path = (payload.get("cover") or {}).get("path")
+        english_title = title.get("english")
+        japanese_title = title.get("japanese")
+        pretty_title = title.get("pretty")
+        language_tag_ids = [tag["id"] for tag in tags if tag.get("type") == "language" and tag.get("id")]
+        category_tag_ids = [tag["id"] for tag in tags if tag.get("type") == "category" and tag.get("id")]
+        artist_tag_ids = [tag["id"] for tag in tags if tag.get("type") == "artist" and tag.get("id")]
+        return NhentaiBookInfo(
+            id=gallery_id, media_id=media_id,
+            name=cls._select_title(english_title=english_title, japanese_title=japanese_title, pretty_title=pretty_title),
+            english_title=english_title, japanese_title=japanese_title, pretty_title=pretty_title,
+            preview_url=cls.gallery_url_template % gallery_id, url=cls.gallery_api_url_template % gallery_id,
+            pages=int(cls._required(payload, "num_pages")), img_preview=cls.build_thumbnail_url(thumbnail_path or cover_path),
+            lang=cls._language_from_tag_ids(language_tag_ids), artist=cls._artist_from_tag_ids(artist_tag_ids),
+            btype=cls._category_from_tag_ids(category_tag_ids),
+            tags=[tag.get("name") for tag in tags if tag.get("type") != "language" and tag.get("name")], pics=pics,
+        )
+
+    @classmethod
+    def apply_detail(cls, book: NhentaiBookInfo, detail: NhentaiBookInfo):
+        for attr in (
+            "id", "media_id", "name", "english_title", "japanese_title", "pretty_title", "url", "preview_url", "pages",
+            "img_preview", "lang", "artist", "btype", "tags", "pics",
+        ):
+            setattr(book, attr, getattr(detail, attr, None))
+        return book
+
+    @classmethod
+    def build_page_image_map(cls, book: NhentaiBookInfo) -> dict[int, str]:
+        pics = getattr(book, "pics", None)
+        if not isinstance(pics, list) or not pics:
+            raise NhentaiParseError("nhentai gallery detail 缺少 pics，无法产出图片 URL")
+        image_map = {}
+        for idx, page in enumerate(pics, start=1):
+            if not isinstance(page, dict):
+                raise NhentaiParseError(f"nhentai page asset 第 {idx} 项不是对象")
+            image_map[int(cls._required(page, "number"))] = cls.build_image_url(cls._required(page, "path"))
+        return image_map
+
+    @classmethod
+    def build_page_image_urls(cls, book: NhentaiBookInfo) -> list[str]:
+        return [url for _, url in sorted(cls.build_page_image_map(book).items())]
+
+    @classmethod
+    def parse_preview_books(cls, resp_text):
+        books = cls.parse_search(resp_text)
+        for idx, book in enumerate(books, start=1):
+            book.idx = idx
+        return books
+
+
+class NhentaiReqer(_NhentaiContract, Cookies, Req):
+    def __init__(self, _conf):
+        self.cli = self.get_cli(_conf)
+
+    @classmethod
+    def get_cli(cls, _conf, is_async=False, **kwargs):
+        cli = super().get_cli(_conf, is_async=is_async, **kwargs)
+        cli.headers = dict(cls.book_hea)
+        return cli
+
+    def test_index(self):
+        try:
+            resp = self.cli.get(self.index, follow_redirects=True, timeout=3.5)
+            resp.raise_for_status()
+        except httpx.HTTPError:
+            return False
+        return bool(resp.text)
+
+    def _headers(self, *, referer: str | None = None) -> dict:
+        return self.with_referer(referer)
+
+    async def preview_search(self, keyword: str, *, page: int = 1):
+        owner = self._require_preview_owner()
+        owner_type = type(owner)
+        site_kw = self.preview_site_kwargs()
+        mappings = owner_type.merge_search_mappings(self.mappings, site_kw.get("custom_map"))
+        if keyword in mappings:
+            url = owner_type.build_page_url(mappings[keyword], page, self.turn_page_info)
+            referer = self.index
+        else:
+            url = owner_type.build_search_url(keyword, page=page)
+            referer = f"{self.index}?page={max(1, int(page or 1))}"
+        client = self.ensure_preview_client()
+        headers = self._headers(referer=referer)
+        resp = await client.get(url, headers=headers, follow_redirects=True, timeout=12)
+        resp.raise_for_status()
+        return await asyncio.to_thread(owner.parser.parse_preview_books, resp.text)
+
+    async def preview_fetch_pages(self, item):
+        if not getattr(item, "url", None):
+            raise ValueError("nhentai book url is required for preview_fetch_pages")
+        client = self.ensure_preview_client()
+        headers = self._headers(referer=item.preview_url)
+        resp = await client.get(item.url, headers=headers, follow_redirects=True, timeout=12)
+        resp.raise_for_status()
+        detail = self.owner.parser.parse_book(resp.text)
+        self.owner.parser.apply_detail(item, detail)
+        return self.owner.parser.build_page_image_urls(item)
+
+
+class NhentaiUtils(_NhentaiContract, EroUtils, Cookies, Previewer):
+    parser = NhentaiParser
+    reqer_cls = NhentaiReqer
+    browser_referer_mode = "provider_index"
+
+    def __init__(self, _conf):
+        self.reqer = self.reqer_cls(_conf)
+        self.parser = self.__class__.parser
+        self.ensure_tag_catalog_loaded()
+
+    @classmethod
+    def preview_client_config(cls, **context):
+        return {"headers": cls.with_referer(cls.index)}

--- a/utils/website/nhentai/gen_assets.py
+++ b/utils/website/nhentai/gen_assets.py
@@ -1,0 +1,215 @@
+import argparse
+import json
+import random
+import sqlite3
+import time
+from contextlib import closing
+from pathlib import Path
+
+import httpx
+
+from assets import res
+from utils import conf, ori_path
+
+
+API_URL = "https://nhentai.net/api/v2"
+TAG_TYPES = [
+    ("parody", 1),
+    ("character", 2),
+    ("tag", 3),
+    ("artist", 4),
+    ("group", 5),
+    ("language", 6),
+    ("category", 7),
+]
+TYPE_BY_CATEGORY = {category: name for name, category in TAG_TYPES}
+HEADERS = {
+    "accept": "application/json",
+    "accept-language": res.Vars.ua_accept_language,
+    "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:150.0) Gecko/20100101 Firefox/150.0",
+    "referer": "https://nhentai.net/",
+}
+
+
+def _make_client(proxy_addr=None):
+    kwargs = dict(http2=True, headers=HEADERS)
+    if proxy_addr:
+        kwargs["proxy"] = f"http://{proxy_addr}"
+    return httpx.Client(**kwargs)
+
+
+def _get_paths(db_path_override=None):
+    if db_path_override:
+        db_p = Path(db_path_override)
+        db_p.parent.mkdir(parents=True, exist_ok=True)
+        return db_p
+    return ori_path.joinpath("__temp/nhentai.db")
+
+
+def _get_proxy():
+    return (conf.proxies or [None])[0]
+
+
+def _default_seed_path():
+    return ori_path.joinpath("test/analyze/nhentai/tags.json")
+
+
+class Db:
+    tags_tb = """
+        CREATE TABLE IF NOT EXISTS `tags` (
+            id INTEGER PRIMARY KEY,
+            name TEXT NOT NULL,
+            count INTEGER NOT NULL DEFAULT 0,
+            type TEXT NOT NULL,
+            category INTEGER NOT NULL
+        );
+    """
+    tags_type_idx = "CREATE INDEX IF NOT EXISTS `idx_tags_type` ON `tags` (`type`);"
+    tags_name_idx = "CREATE INDEX IF NOT EXISTS `idx_tags_name` ON `tags` (`name`);"
+
+    @classmethod
+    def create_tables(cls, db_p):
+        with closing(sqlite3.connect(db_p)) as db_conn:
+            cursor = db_conn.cursor()
+            cursor.execute(cls.tags_tb)
+            cursor.execute(cls.tags_type_idx)
+            cursor.execute(cls.tags_name_idx)
+            db_conn.commit()
+
+
+def _request_with_retry(client, url, max_retries=3, base_delay=2, jitter=1, timeout=10):
+    for attempt in range(max_retries + 1):
+        try:
+            resp = client.get(url, timeout=timeout)
+            if resp.status_code == 429 and attempt < max_retries:
+                delay = base_delay * (2 ** attempt) + random.uniform(0, jitter)
+                print(f"  [RATE_LIMIT] retry {attempt + 1}/{max_retries} after {delay:.1f}s")
+                time.sleep(delay)
+                continue
+            resp.raise_for_status()
+            return resp.json()
+        except (httpx.HTTPError, httpx.TimeoutException, json.JSONDecodeError) as exc:
+            if attempt == max_retries:
+                raise
+            delay = base_delay * (2 ** attempt) + random.uniform(0, jitter)
+            print(f"  [RETRY] {attempt + 1}/{max_retries} after {delay:.1f}s - {exc}")
+            time.sleep(delay)
+
+
+def _normalize_seed_row(row):
+    if not isinstance(row, list) or len(row) != 4:
+        raise ValueError(f"invalid nhentai tag seed row: {row!r}")
+    tag_id, name, count, category = row
+    category = int(category)
+    tag_type = TYPE_BY_CATEGORY.get(category)
+    if tag_type is None:
+        raise ValueError(f"invalid nhentai tag category: {category}")
+    return int(tag_id), str(name), int(count), tag_type, category
+
+
+def load_seed_tags(seed_path):
+    seed_p = Path(seed_path)
+    if not seed_p.exists():
+        return []
+    data = json.loads(seed_p.read_text(encoding="utf-8"))
+    if not isinstance(data, list):
+        raise ValueError(f"nhentai tag seed root must be list: {seed_p}")
+    return [_normalize_seed_row(row) for row in data]
+
+
+def _normalize_api_row(row, tag_type, category):
+    if not isinstance(row, dict):
+        raise ValueError(f"invalid nhentai tag API row: {row!r}")
+    return int(row["id"]), str(row["name"]), int(row["count"]), tag_type, category
+
+
+def _scrape_type(client, tag_type, category, per_page=100, delay=2, timeout=10, max_retries=3):
+    current_page = 1
+    while True:
+        print(f"Getting tags type '{tag_type}' page {current_page}")
+        payload = _request_with_retry(
+            client, f"{API_URL}/tags/{tag_type}?page={current_page}&per_page={per_page}", max_retries=max_retries, timeout=timeout,
+        )
+        results = payload.get("result")
+        if not isinstance(results, list):
+            raise ValueError(f"nhentai tags/{tag_type} page {current_page} missing result list")
+        for row in results:
+            yield _normalize_api_row(row, tag_type, category)
+        num_pages = int(payload.get("num_pages") or 0)
+        if current_page >= num_pages:
+            break
+        current_page += 1
+        if delay:
+            time.sleep(delay)
+
+
+def _save_tags(db_conn, rows):
+    with closing(db_conn.cursor()) as cursor:
+        cursor.executemany(
+            """
+            INSERT INTO `tags` (id, name, count, type, category) VALUES (?, ?, ?, ?, ?)
+            ON CONFLICT(id) DO UPDATE SET
+                name=excluded.name,
+                count=excluded.count,
+                type=excluded.type,
+                category=excluded.category
+            """,
+            rows,
+        )
+        db_conn.commit()
+        return cursor.rowcount
+
+
+def seed_and_scrape(db_p, seed_path=None, skip_online=False, per_page=100, delay=2, timeout=10, max_retries=3):
+    total_written = 0
+    with closing(sqlite3.connect(db_p)) as db_conn:
+        seed_rows = load_seed_tags(seed_path or _default_seed_path())
+        if seed_rows:
+            total_written += _save_tags(db_conn, seed_rows)
+            print(f"[SEED] written {len(seed_rows)} rows")
+        if skip_online:
+            print(f"[DONE] seed only, sqlite rows affected {total_written}")
+            return True
+
+        client = _make_client(_get_proxy())
+        failed = []
+        for tag_type, category in TAG_TYPES:
+            try:
+                rows = list(
+                    _scrape_type(client, tag_type, category, per_page=per_page, delay=delay, timeout=timeout, max_retries=max_retries)
+                )
+                total_written += _save_tags(db_conn, rows)
+                print(f"[SUCCESS] {tag_type} written {len(rows)} rows")
+            except Exception as exc:
+                print(f"[ERROR] {tag_type} {exc}")
+                failed.append(tag_type)
+        print(f"\n{'=' * 40}\n[DONE] sqlite rows affected {total_written}, failed {len(failed)}")
+        if failed:
+            print(f"[FAILED] {failed}")
+        return not failed
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Scrape nhentai tag dataset into SQLite")
+    parser.add_argument("--db-path", type=str, default=None, help="override nhentai.db path (for CI)")
+    parser.add_argument(
+        "--seed-json", type=str, default=None, help="seed JSON path, defaults to test/analyze/nhentai/tags.json when present"
+    )
+    parser.add_argument("--skip-online", action="store_true", help="only import seed JSON into SQLite")
+    parser.add_argument("--per-page", type=int, default=100, help="API page size (default: 100)")
+    parser.add_argument("--delay", type=float, default=2, help="delay between API pages in seconds (default: 2)")
+    parser.add_argument("--max-retries", type=int, default=3, help="max retries per request (default: 3)")
+    parser.add_argument("--timeout", type=int, default=10, help="request timeout in seconds (default: 10)")
+    args = parser.parse_args()
+
+    db_p = _get_paths(args.db_path)
+    Db.create_tables(db_p)
+    success = seed_and_scrape(
+        db_p, seed_path=args.seed_json, skip_online=args.skip_online, per_page=args.per_page, delay=args.delay,
+        max_retries=args.max_retries, timeout=args.timeout,
+    )
+    exit(0 if success else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/utils/website/preprocess.py
+++ b/utils/website/preprocess.py
@@ -95,7 +95,9 @@ def _preprocess_jm_like(gui_site_runtime: "GuiSiteRuntime") -> PreprocessResult:
         domain = gui_site_runtime.get_domain()
     except (httpx.HTTPError, RuntimeError, ValueError) as exc:
         return PreprocessResult(
-            ready=False, block_search=True, messages=(_message("error", "<br>❌ 域名获取/测试失效，按内置浏览器引导操作"),), actions=(_action("open_publish_flow"),),
+            ready=False, block_search=True, 
+            messages=(_message("error", "<br>❌ 域名获取/测试失效，按内置浏览器引导操作"),),
+            actions=(_action("open_publish_flow"),),
             state_flags={"cache_hit": cache_hit, "domain_ready": False, "error": str(exc)},
         )
     message = ("<br>➖ 缓存处于有效期内，跳过测试" if cache_hit else "<br>✅ 已设置有效域名")

--- a/utils/website/preprocess.py
+++ b/utils/website/preprocess.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import importlib
 import json
 import os
@@ -20,34 +21,42 @@ if t.TYPE_CHECKING:
     from .site_runtime import GuiSiteRuntime
 
 
-def run_site_preprocess(
+async def run_site_preprocess(
     site_key: int,
     *,
     gui_site_runtime: "GuiSiteRuntime | None" = None,
     conf_state=conf,
-    data_client: httpx.Client | None = None,
+    data_client: httpx.AsyncClient | None = None,
     progress_callback=None,
 ) -> PreprocessResult:
-    if site_key == Spider.MANGA_COPY:
-        return _preprocess_manga_copy(_require_gui_site_runtime(site_key, gui_site_runtime), conf_state=conf_state)
-    if site_key == Spider.JM:
-        return _preprocess_jm_like(_require_gui_site_runtime(site_key, gui_site_runtime))
-    if site_key == Spider.WNACG:
-        return _preprocess_wnacg(_require_gui_site_runtime(site_key, gui_site_runtime), conf_state=conf_state)
-    if site_key == Spider.EHENTAI:
-        return _preprocess_ehentai(_require_gui_site_runtime(site_key, gui_site_runtime), conf_state=conf_state)
-    if site_key == Spider.HITOMI:
-        return _preprocess_hitomi(
-            _require_gui_site_runtime(site_key, gui_site_runtime),
-            conf_state=conf_state,
-            data_client=_ensure_data_client(data_client),
-            progress_callback=progress_callback,
-        )
-    if site_key == 7:
-        return _preprocess_script(data_client=_ensure_data_client(data_client), progress_callback=progress_callback)
-    if gui_site_runtime is not None:
-        return _preprocess_test_index(_require_gui_site_runtime(site_key, gui_site_runtime))
-    return PreprocessResult()
+    owns_data_client = data_client is None
+    resolved_data_client = data_client
+    try:
+        if site_key == Spider.MANGA_COPY:
+            return await _preprocess_manga_copy(_require_gui_site_runtime(site_key, gui_site_runtime), conf_state=conf_state)
+        if site_key == Spider.JM:
+            return _preprocess_jm_like(_require_gui_site_runtime(site_key, gui_site_runtime))
+        if site_key == Spider.WNACG:
+            return _preprocess_wnacg(_require_gui_site_runtime(site_key, gui_site_runtime), conf_state=conf_state)
+        if site_key == Spider.EHENTAI:
+            return await _preprocess_ehentai(_require_gui_site_runtime(site_key, gui_site_runtime), conf_state=conf_state)
+        if site_key == Spider.HITOMI:
+            resolved_data_client = _ensure_data_client(resolved_data_client)
+            return await _preprocess_hitomi(_require_gui_site_runtime(site_key, gui_site_runtime), conf_state=conf_state,
+                data_client=resolved_data_client, progress_callback=progress_callback)
+        if site_key == Spider.NHENTAI:
+            resolved_data_client = _ensure_data_client(resolved_data_client)
+            return await _preprocess_nhentai(_require_gui_site_runtime(site_key, gui_site_runtime),
+                data_client=resolved_data_client, progress_callback=progress_callback)
+        if site_key == 7:
+            resolved_data_client = _ensure_data_client(resolved_data_client)
+            return await _preprocess_script(data_client=resolved_data_client, progress_callback=progress_callback)
+        if gui_site_runtime is not None:
+            return await _preprocess_test_index(_require_gui_site_runtime(site_key, gui_site_runtime))
+        return PreprocessResult()
+    finally:
+        if owns_data_client and resolved_data_client is not None:
+            await resolved_data_client.aclose()
 
 
 def _require_gui_site_runtime(site_key: int, gui_site_runtime: "GuiSiteRuntime | None") -> "GuiSiteRuntime":
@@ -56,10 +65,10 @@ def _require_gui_site_runtime(site_key: int, gui_site_runtime: "GuiSiteRuntime |
     return gui_site_runtime
 
 
-def _ensure_data_client(data_client: httpx.Client | None) -> httpx.Client:
+def _ensure_data_client(data_client: httpx.AsyncClient | None) -> httpx.AsyncClient:
     if data_client is not None:
         return data_client
-    return httpx.Client(transport=httpx.HTTPTransport(retries=2))
+    return httpx.AsyncClient(transport=httpx.AsyncHTTPTransport(retries=2))
 
 
 def _message(level: str, text: str, *, channel: str = "text", **kwargs) -> dict[str, t.Any]:
@@ -74,14 +83,14 @@ def _domain_cache_hit(gui_site_runtime: "GuiSiteRuntime") -> bool:
     return bool(gui_site_runtime.peek_cached_domain())
 
 
-def _preprocess_manga_copy(gui_site_runtime: "GuiSiteRuntime", *, conf_state=conf) -> PreprocessResult:
+async def _preprocess_manga_copy(gui_site_runtime: "GuiSiteRuntime", *, conf_state=conf) -> PreprocessResult:
     runtime = gui_site_runtime.create_thread_site_runtime()
     reqer = runtime.reqer
     try:
         reqer.get_aes_key()
         cache_hit = reqer.aes_cache_hit()
     finally:
-        runtime.close()
+        await runtime.aclose()
     message = (
         "<br>➖ 缓存处于有效期内，跳过测试"
         if cache_hit else "<br>✅ 拷贝预处理完成"
@@ -94,75 +103,54 @@ def _preprocess_jm_like(gui_site_runtime: "GuiSiteRuntime") -> PreprocessResult:
     try:
         domain = gui_site_runtime.get_domain()
     except (httpx.HTTPError, RuntimeError, ValueError) as exc:
-        return PreprocessResult(
-            ready=False, block_search=True, 
-            messages=(_message("error", "<br>❌ 域名获取/测试失效，按内置浏览器引导操作"),),
-            actions=(_action("open_publish_flow"),),
-            state_flags={"cache_hit": cache_hit, "domain_ready": False, "error": str(exc)},
-        )
+        return PreprocessResult(ready=False, block_search=True, messages=(_message("error", "<br>❌ 域名获取/测试失效，按内置浏览器引导操作"),),
+            actions=(_action("open_publish_flow"),), state_flags={"cache_hit": cache_hit, "domain_ready": False, "error": str(exc)})
     message = ("<br>➖ 缓存处于有效期内，跳过测试" if cache_hit else "<br>✅ 已设置有效域名")
-    return PreprocessResult(
-        ready=True, domain=domain, runtime_ready=True, messages=(_message("success", message),), state_flags={"cache_hit": cache_hit, "domain_ready": True},
-    )
+    return PreprocessResult(ready=True, domain=domain, runtime_ready=True, messages=(_message("success", message),),
+        state_flags={"cache_hit": cache_hit, "domain_ready": True})
 
 
 def _preprocess_wnacg(gui_site_runtime: "GuiSiteRuntime", *, conf_state=conf) -> PreprocessResult:
     if conf_state.proxies:
         domain = gui_site_runtime.peek_cached_domain() or gui_site_runtime.provider_cls.domain
-        return PreprocessResult(
-            ready=True,
-            domain=domain,
-            runtime_ready=True,
-            messages=(_message("info", "🔔 已设置代理，跳过域名缓存处理"),),
-            state_flags={"proxy_configured": True, "domain_ready": True},
-        )
+        return PreprocessResult(ready=True, domain=domain, runtime_ready=True, messages=(_message("info", "🔔 已设置代理，跳过域名缓存处理"),),
+            state_flags={"proxy_configured": True, "domain_ready": True})
     return _preprocess_jm_like(gui_site_runtime)
 
 
-def _preprocess_ehentai(gui_site_runtime: "GuiSiteRuntime", *, conf_state=conf) -> PreprocessResult:
+async def _preprocess_ehentai(gui_site_runtime: "GuiSiteRuntime", *, conf_state=conf) -> PreprocessResult:
     cookies_ready = bool(conf_state.cookies.get("ehentai"))
     if not cookies_ready:
-        return PreprocessResult(
-            ready=False,
-            block_search=True,
+        return PreprocessResult(ready=False, block_search=True,
             messages=(_message("error", res.EHentai.COOKIES_NOT_SET, channel="infobar"),),
-            state_flags={"cookies_ready": False, "access_ready": False},
-        )
+            state_flags={"cookies_ready": False, "access_ready": False})
 
     runtime = gui_site_runtime.create_thread_site_runtime()
     access_ready = bool(runtime.reqer.test_index())
     provider_index = gui_site_runtime.provider_cls.index
     provider_domain = gui_site_runtime.provider_cls.domain
     if not access_ready:
-        runtime.close()
-        return PreprocessResult(
-            ready=False,
-            block_search=True,
+        await runtime.aclose()
+        return PreprocessResult(ready=False, block_search=True,
             messages=(_message("error", res.EHentai.ACCESS_FAIL, channel="custom", url=provider_index, url_name=gui_site_runtime.name),),
-            state_flags={"cookies_ready": True, "access_ready": False},
-        )
+            state_flags={"cookies_ready": True, "access_ready": False})
 
-    return PreprocessResult(
-        ready=True,
-        domain=provider_domain,
-        runtime_ready=True,
-        messages=(_message("success", "<br>✅ exhentai access pass"),),
-        actions=(_action("attach_ehentai_runtime", runtime=runtime),),
-        state_flags={"cookies_ready": True, "access_ready": True},
-    )
+    return PreprocessResult(ready=True, domain=provider_domain, runtime_ready=True,
+        messages=(_message("success", "<br>✅ exhentai access pass"),), actions=(_action("attach_ehentai_runtime", runtime=runtime),),
+        state_flags={"cookies_ready": True, "access_ready": True})
 
-def _preprocess_hitomi(
+async def _preprocess_hitomi(
     gui_site_runtime: "GuiSiteRuntime",
     *,
     conf_state=conf,
-    data_client: httpx.Client,
+    data_client: httpx.AsyncClient,
     progress_callback=None,
 ) -> PreprocessResult:
     runtime = gui_site_runtime.create_thread_site_runtime()
     try:
         access_ready = bool(runtime.reqer.test_index())
     finally:
-        runtime.close()
+        await runtime.aclose()
     provider_index = gui_site_runtime.provider_cls.index
     messages: list[dict[str, t.Any]] = []
     actions: list[dict[str, t.Any]] = []
@@ -171,23 +159,17 @@ def _preprocess_hitomi(
     if access_ready:
         messages.append(_message("success", "<br>✅ hitomi access pass"))
     else:
-        access_fail_message = _message(
-            "error",
-            "",
-            channel="custom",
-            text_key="ACCESS_FAIL",
-            url=provider_index,
-            url_name=gui_site_runtime.name,
-        )
+        access_fail_message = _message("error", "", channel="custom", text_key="ACCESS_FAIL", url=provider_index,
+            url_name=gui_site_runtime.name)
         messages.append(access_fail_message)
 
-    hitomi_db_path = ori_path.joinpath("assets/hitomi.db")
+    hitomi_db_path = ori_path.joinpath("__temp/hitomi.db")
     data_ready = hitomi_db_path.exists()
     if not data_ready:
         if callable(progress_callback):
             progress_callback("hitomi db downloading...")
         messages.append(_message("warning", "⚠️ hitomi db not found, downloading..."))
-        data_ready, download_errors = _download_hitomi_db(hitomi_db_path, data_client)
+        data_ready, download_errors = await _download_hitomi_db(hitomi_db_path, data_client)
         if download_errors:
             state_flags["hitomi_db_errors"] = tuple(download_errors)
         if data_ready:
@@ -198,22 +180,63 @@ def _preprocess_hitomi(
         actions.append(_action("add_hitomi_tool"))
     state_flags["data_ready"] = data_ready
 
-    return PreprocessResult(
-        ready=access_ready,
-        block_search=False,
-        runtime_ready=access_ready,
-        messages=tuple(messages),
-        actions=tuple(actions),
-        state_flags=state_flags,
-    )
+    return PreprocessResult(ready=access_ready, block_search=False, runtime_ready=access_ready, messages=tuple(messages),
+        actions=tuple(actions), state_flags=state_flags)
 
 
-def _preprocess_test_index(gui_site_runtime: "GuiSiteRuntime") -> PreprocessResult:
+async def _preprocess_nhentai(
+    gui_site_runtime: "GuiSiteRuntime", *, data_client: httpx.AsyncClient, progress_callback=None
+) -> PreprocessResult:
     runtime = gui_site_runtime.create_thread_site_runtime()
     try:
         access_ready = bool(runtime.reqer.test_index())
     finally:
-        runtime.close()
+        await runtime.aclose()
+    provider_index = gui_site_runtime.provider_cls.index
+    messages: list[dict[str, t.Any]] = []
+    state_flags: dict[str, t.Any] = {"access_ready": access_ready}
+
+    if access_ready:
+        messages.append(_message("success", "<br>\u2705 nhentai access pass"))
+    else:
+        messages.append(_message("error", "", channel="custom", text_key="ACCESS_FAIL", url=provider_index, url_name=gui_site_runtime.name))
+
+    db_path = ori_path.joinpath("__temp/nhentai.db")
+    data_ready = db_path.exists()
+    if not data_ready:
+        if callable(progress_callback):
+            progress_callback("nhentai db downloading...")
+        messages.append(_message("warning", "\u26a0\ufe0f nhentai db not found, downloading..."))
+        data_ready, download_errors = await _download_nhentai_db(db_path, data_client)
+        if download_errors:
+            state_flags["nhentai_db_errors"] = tuple(download_errors)
+        if data_ready:
+            messages.append(_message("success", "<br>\u2705 nhentai db downloaded"))
+        else:
+            messages.append(_message("error", "<br>\u274c nhentai-db download failed"))
+    if data_ready:
+        from .nhentai import NhentaiUtils
+
+        try:
+            state_flags["nhentai_tag_catalog_counts"] = NhentaiUtils.preload_tag_catalog(db_path)
+        except Exception as exc:
+            data_ready = False
+            state_flags["nhentai_db_preload_error"] = str(exc)
+            messages.append(_message("error", f"<br>\u274c nhentai tag catalog preload failed: {exc}"))
+        else:
+            messages.append(_message("success", "<br>\u2705 nhentai tag catalog preloaded"))
+    state_flags["data_ready"] = data_ready
+
+    return PreprocessResult(ready=access_ready and data_ready, block_search=False, runtime_ready=access_ready and data_ready,
+        messages=tuple(messages), state_flags=state_flags)
+
+
+async def _preprocess_test_index(gui_site_runtime: "GuiSiteRuntime") -> PreprocessResult:
+    runtime = gui_site_runtime.create_thread_site_runtime()
+    try:
+        access_ready = bool(runtime.reqer.test_index())
+    finally:
+        await runtime.aclose()
     if not access_ready:
         return PreprocessResult(
             ready=False, block_search=True,
@@ -221,14 +244,12 @@ def _preprocess_test_index(gui_site_runtime: "GuiSiteRuntime") -> PreprocessResu
                 url=gui_site_runtime.provider_cls.index, url_name=gui_site_runtime.name),),
             state_flags={"access_ready": False},
         )
-    return PreprocessResult(
-        ready=True, runtime_ready=True,
-        messages=(_message("success", f"<br>✅ {gui_site_runtime.name} 访问检测通过"),),
-        state_flags={"access_ready": True},
-    )
+    return PreprocessResult(ready=True, runtime_ready=True,
+        messages=(_message("success", f"<br>✅ {gui_site_runtime.name} 访问检测通过"),), state_flags={"access_ready": True})
 
 
-def _download_hitomi_db(db_path: Path, data_client: httpx.Client) -> tuple[bool, list[str]]:
+async def _download_hitomi_db(db_path: Path, data_client: httpx.AsyncClient) -> tuple[bool, list[str]]:
+    db_path.parent.mkdir(parents=True, exist_ok=True)
     urls = (
         "https://github.com/jasoneri/ComicGUISpider/releases/download/preset/hitomi.db",
         res.Vars.hitomiDb_tmp_url,
@@ -238,10 +259,10 @@ def _download_hitomi_db(db_path: Path, data_client: httpx.Client) -> tuple[bool,
     try:
         for url in urls:
             try:
-                with data_client.stream("GET", url, follow_redirects=True, timeout=30) as resp:
+                async with data_client.stream("GET", url, follow_redirects=True, timeout=30) as resp:
                     resp.raise_for_status()
                     with open(tmp_path, "wb") as file_obj:
-                        for chunk in resp.iter_bytes(chunk_size=8192):
+                        async for chunk in resp.aiter_bytes(chunk_size=8192):
                             file_obj.write(chunk)
                 os.replace(str(tmp_path), str(db_path))
                 return True, errors
@@ -253,7 +274,30 @@ def _download_hitomi_db(db_path: Path, data_client: httpx.Client) -> tuple[bool,
         tmp_path.unlink(missing_ok=True)
 
 
-def _preprocess_script(*, data_client: httpx.Client, progress_callback=None) -> PreprocessResult:
+async def _download_nhentai_db(db_path: Path, data_client: httpx.AsyncClient) -> tuple[bool, list[str]]:
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    urls = ("https://github.com/jasoneri/ComicGUISpider/releases/download/preset/nhentai.db",)
+    tmp_path = db_path.with_suffix(".db.tmp")
+    errors: list[str] = []
+    try:
+        for url in urls:
+            try:
+                async with data_client.stream("GET", url, follow_redirects=True, timeout=30) as resp:
+                    resp.raise_for_status()
+                    with open(tmp_path, "wb") as file_obj:
+                        async for chunk in resp.aiter_bytes(chunk_size=8192):
+                            file_obj.write(chunk)
+                os.replace(str(tmp_path), str(db_path))
+                return True, errors
+            except Exception as exc:
+                tmp_path.unlink(missing_ok=True)
+                errors.append(f"{url}: {exc}")
+        return False, errors
+    finally:
+        tmp_path.unlink(missing_ok=True)
+
+
+async def _preprocess_script(*, data_client: httpx.AsyncClient, progress_callback=None) -> PreprocessResult:
     script_res = res.GUI.Script
     services_ready = _check_script_services()
     dependencies_result = _check_script_dependencies()
@@ -269,28 +313,16 @@ def _preprocess_script(*, data_client: httpx.Client, progress_callback=None) -> 
     if services_ready:
         messages.append(_message("success", script_res.service_check_success))
     else:
-        service_fail_message = _message(
-            "error",
-            script_res.service_check_failed_content,
-            channel="custom",
-            title=script_res.service_check_failed_title,
-            url=f"{CGS_DOC}/script",
-            url_name=script_res.guide_name,
-        )
+        service_fail_message = _message("error", script_res.service_check_failed_content, channel="custom",
+            title=script_res.service_check_failed_title, url=f"{CGS_DOC}/script", url_name=script_res.guide_name)
         messages.append(service_fail_message)
 
     if dependencies_ready:
         messages.append(_message("success", script_res.dependency_check_success))
     else:
         missing = tuple(dependencies_result)
-        dependency_fail_message = _message(
-            "error",
-            script_res.dependency_check_failed_content,
-            channel="custom",
-            title=script_res.dependency_check_failed_title,
-            url=f"{CGS_DOC}/script",
-            url_name=script_res.guide_name,
-        )
+        dependency_fail_message = _message("error", script_res.dependency_check_failed_content, channel="custom",
+            title=script_res.dependency_check_failed_title, url=f"{CGS_DOC}/script", url_name=script_res.guide_name)
         messages.append(dependency_fail_message)
         actions.append(_action("launch_update_flow"))
         state_flags["missing_dependencies"] = missing
@@ -298,7 +330,7 @@ def _preprocess_script(*, data_client: httpx.Client, progress_callback=None) -> 
     if not services_ready or not dependencies_ready:
         return PreprocessResult(ready=False, block_search=True, messages=tuple(messages), actions=tuple(actions), state_flags=state_flags)
 
-    data_ready, data_cache_hit = _check_kemono_data(data_client, progress_callback=progress_callback)
+    data_ready, data_cache_hit = await _check_kemono_data(data_client, progress_callback=progress_callback)
     state_flags["data_ready"] = data_ready
     state_flags["data_cache_hit"] = data_cache_hit
     if data_ready:
@@ -307,14 +339,8 @@ def _preprocess_script(*, data_client: httpx.Client, progress_callback=None) -> 
     else:
         messages.append(_message("error", script_res.data_cache_check_failed))
 
-    return PreprocessResult(
-        ready=data_ready,
-        block_search=True,
-        runtime_ready=data_ready,
-        messages=tuple(messages),
-        actions=tuple(actions),
-        state_flags=state_flags,
-    )
+    return PreprocessResult(ready=data_ready, block_search=True, runtime_ready=data_ready, messages=tuple(messages),
+        actions=tuple(actions), state_flags=state_flags)
 
 
 def _check_script_services() -> bool:
@@ -336,32 +362,28 @@ def _check_script_dependencies() -> bool | list[str]:
     return True if not missing else missing
 
 
-def _check_kemono_data(data_client: httpx.Client, *, progress_callback=None) -> tuple[bool, bool]:
+async def _check_kemono_data(data_client: httpx.AsyncClient, *, progress_callback=None) -> tuple[bool, bool]:
     def emit_progress(message: str):
         if callable(progress_callback):
             progress_callback(message)
 
-    def download_kemono_data():
-        emit_progress("正在更新缓存数据...")
-        from utils.script.image.kemono import Api, KemonoAuthor, headers
-
-        with data_client.stream("GET", Api.creators_txt, headers=headers, follow_redirects=True, timeout=60) as resp:
-            resp.raise_for_status()
-            content = b"".join(resp.iter_bytes())
-
-        json_data = json.loads(content.decode("utf-8"))
-        author_dict = {}
-        for item in json_data:
-            author = KemonoAuthor(
-                id=item["id"],
-                name=item["name"],
-                service=item["service"],
-                updated=item["updated"],
-                favorited=item["favorited"],
-            )
-            author_dict[author.id] = author
-        return author_dict
-
     cache = Cache("kemono_data.pkl")
-    cache.run(download_kemono_data, 240, write_in=True)
-    return True, cache.flag != "new"
+    await asyncio.to_thread(cache.run, lambda: None, 240)
+    if cache.flag == "validate":
+        return True, True
+
+    emit_progress("正在更新缓存数据...")
+    from utils.script.image.kemono import Api, KemonoAuthor, headers
+
+    async with data_client.stream("GET", Api.creators_txt, headers=headers, follow_redirects=True, timeout=60) as resp:
+        resp.raise_for_status()
+        content = b"".join([chunk async for chunk in resp.aiter_bytes()])
+
+    json_data = json.loads(content.decode("utf-8"))
+    author_dict = {}
+    for item in json_data:
+        author = KemonoAuthor(id=item["id"], name=item["name"], service=item["service"], updated=item["updated"],
+            favorited=item["favorited"])
+        author_dict[author.id] = author
+    await asyncio.to_thread(cache.run, lambda: author_dict, 240, True)
+    return True, False

--- a/utils/website/preprocess.py
+++ b/utils/website/preprocess.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
-import asyncio
+from dataclasses import dataclass
 import importlib
-import json
 import os
 from pathlib import Path
 import typing as t
@@ -12,6 +11,7 @@ import psutil
 
 from assets import res
 from utils import conf, ori_path
+from utils.network.doh import build_http_transport
 from variables import CGS_DOC, Spider
 
 from .contracts import PreprocessResult
@@ -21,54 +21,70 @@ if t.TYPE_CHECKING:
     from .site_runtime import GuiSiteRuntime
 
 
+DB_CACHE_TTL_HOURS = 480
+KEMONO_ASSET_URL = "https://github.com/jasoneri/ComicGUISpider/releases/download/preset/kemono.db"
+NHENTAI_ASSET_URL = "https://github.com/jasoneri/ComicGUISpider/releases/download/preset/nhentai.db"
+HITOMI_ASSET_URL = "https://github.com/jasoneri/ComicGUISpider/releases/download/preset/hitomi.db"
+
+
 async def run_site_preprocess(
-    site_key: int,
-    *,
-    gui_site_runtime: "GuiSiteRuntime | None" = None,
-    conf_state=conf,
-    data_client: httpx.AsyncClient | None = None,
-    progress_callback=None,
+    gui_site_runtime: "GuiSiteRuntime", *, conf_state=conf, data_client: httpx.AsyncClient | None = None, progress_callback=None
 ) -> PreprocessResult:
+    if gui_site_runtime is None:
+        raise ValueError("run_site_preprocess requires gui_site_runtime")
     owns_data_client = data_client is None
     resolved_data_client = data_client
+    site_key = gui_site_runtime.site_index
     try:
         if site_key == Spider.MANGA_COPY:
-            return await _preprocess_manga_copy(_require_gui_site_runtime(site_key, gui_site_runtime), conf_state=conf_state)
+            return await _preprocess_manga_copy(gui_site_runtime)
         if site_key == Spider.JM:
-            return _preprocess_jm_like(_require_gui_site_runtime(site_key, gui_site_runtime))
+            return _preprocess_jm_like(gui_site_runtime)
         if site_key == Spider.WNACG:
-            return _preprocess_wnacg(_require_gui_site_runtime(site_key, gui_site_runtime), conf_state=conf_state)
+            return _preprocess_wnacg(gui_site_runtime, conf_state=conf_state)
         if site_key == Spider.EHENTAI:
-            return await _preprocess_ehentai(_require_gui_site_runtime(site_key, gui_site_runtime), conf_state=conf_state)
+            return await _preprocess_ehentai(gui_site_runtime, conf_state=conf_state)
         if site_key == Spider.HITOMI:
-            resolved_data_client = _ensure_data_client(resolved_data_client)
-            return await _preprocess_hitomi(_require_gui_site_runtime(site_key, gui_site_runtime), conf_state=conf_state,
-                data_client=resolved_data_client, progress_callback=progress_callback)
+            resolved_data_client = _ensure_data_client(resolved_data_client, gui_site_runtime=gui_site_runtime, conf_state=conf_state)
+            return await _preprocess_hitomi(gui_site_runtime, data_client=resolved_data_client, progress_callback=progress_callback)
         if site_key == Spider.NHENTAI:
-            resolved_data_client = _ensure_data_client(resolved_data_client)
-            return await _preprocess_nhentai(_require_gui_site_runtime(site_key, gui_site_runtime),
-                data_client=resolved_data_client, progress_callback=progress_callback)
-        if site_key == 7:
-            resolved_data_client = _ensure_data_client(resolved_data_client)
-            return await _preprocess_script(data_client=resolved_data_client, progress_callback=progress_callback)
-        if gui_site_runtime is not None:
-            return await _preprocess_test_index(_require_gui_site_runtime(site_key, gui_site_runtime))
-        return PreprocessResult()
+            resolved_data_client = _ensure_data_client(resolved_data_client, gui_site_runtime=gui_site_runtime, conf_state=conf_state)
+            return await _preprocess_nhentai(gui_site_runtime, data_client=resolved_data_client, progress_callback=progress_callback)
+        return await _preprocess_test_index(gui_site_runtime)
     finally:
         if owns_data_client and resolved_data_client is not None:
             await resolved_data_client.aclose()
 
 
-def _require_gui_site_runtime(site_key: int, gui_site_runtime: "GuiSiteRuntime | None") -> "GuiSiteRuntime":
-    if gui_site_runtime is None:
-        raise ValueError(f"site {site_key!r} preprocess requires gui_site_runtime")
-    return gui_site_runtime
+async def run_script_preprocess(
+    *, conf_state=conf, data_client: httpx.AsyncClient | None = None, progress_callback=None
+) -> PreprocessResult:
+    owns_data_client = data_client is None
+    resolved_data_client = _ensure_data_client(data_client, conf_state=conf_state)
+    try:
+        return await _preprocess_script(data_client=resolved_data_client, progress_callback=progress_callback)
+    finally:
+        if owns_data_client:
+            await resolved_data_client.aclose()
 
 
-def _ensure_data_client(data_client: httpx.AsyncClient | None) -> httpx.AsyncClient:
+def _ensure_data_client(
+    data_client: httpx.AsyncClient | None,
+    *,
+    gui_site_runtime: "GuiSiteRuntime | None" = None,
+    conf_state=conf,
+) -> httpx.AsyncClient:
     if data_client is not None:
         return data_client
-    return httpx.AsyncClient(transport=httpx.AsyncHTTPTransport(retries=2))
+    if gui_site_runtime is not None:
+        transport_config = gui_site_runtime.runtime_context.transport
+        proxies = list(transport_config.proxies)
+        doh_url = transport_config.doh_url
+    else:
+        proxies = list(getattr(conf_state, "proxies", None) or ())
+        doh_url = str(getattr(conf_state, "doh_url", "") or "")
+    transport, trust_env = build_http_transport("proxy", proxies, doh_url=doh_url, is_async=True, retries=2)
+    return httpx.AsyncClient(transport=transport, trust_env=trust_env)
 
 
 def _message(level: str, text: str, *, channel: str = "text", **kwargs) -> dict[str, t.Any]:
@@ -79,18 +95,122 @@ def _action(action_type: str, **kwargs) -> dict[str, t.Any]:
     return {"type": action_type, **kwargs}
 
 
+@dataclass(frozen=True, slots=True)
+class ReleaseAssetResult:
+    ready: bool
+    cache_hit: bool
+    cache_expired: bool
+    db_path: Path
+    errors: tuple[str, ...] = ()
+
+
+class ReleaseAssetCache:
+    def __init__(
+        self, *, name: str, db_path: Path, download_urls: tuple[str, ...], data_client: httpx.AsyncClient,
+        progress_callback=None, label: str | None = None, timeout: int = 30, cache_ttl_hours: int = DB_CACHE_TTL_HOURS,
+    ):
+        self.name = name
+        self.db_path = db_path
+        self.download_urls = download_urls
+        self.data_client = data_client
+        self.progress_callback = progress_callback
+        self.label = label or f"{name} db"
+        self.timeout = timeout
+        self.cache_ttl_hours = cache_ttl_hours
+        self.cache = Cache(f"{name}.db")
+
+    async def ensure(self) -> ReleaseAssetResult:
+        cached_db_path = self.cache.run(lambda: None, self.cache_ttl_hours)
+        if cached_db_path:
+            return ReleaseAssetResult(True, True, False, t.cast(Path, cached_db_path))
+        self._emit_legacy_download_start()
+        ready, errors = await self._download()
+        return ReleaseAssetResult(ready, False, self.cache.state == "expired", self.db_path, tuple(errors))
+
+    def _emit_legacy_download_start(self) -> None:
+        progress_start = getattr(self.progress_callback, "download_start", None)
+        if callable(self.progress_callback) and not callable(progress_start):
+            self.progress_callback(f"{self.label} dling...")
+
+    async def _download(self) -> tuple[bool, list[str]]:
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        tmp_path = self.db_path.with_suffix(".db.tmp")
+        errors: list[str] = []
+        progress_reset = getattr(self.progress_callback, "download_reset", None)
+        progress_start = getattr(self.progress_callback, "download_start", None)
+        progress_advance = getattr(self.progress_callback, "download_advance", None)
+        progress_finish = getattr(self.progress_callback, "download_finish", None)
+        try:
+            for url in self.download_urls:
+                try:
+                    if callable(progress_reset):
+                        progress_reset(label=self.label)
+                    async with self.data_client.stream("GET", url, follow_redirects=True, timeout=self.timeout) as resp:
+                        resp.raise_for_status()
+                        total_header = resp.headers.get("Content-Length", "").strip()
+                        total_bytes = int(total_header) if total_header.isdigit() else None
+                        if callable(progress_start):
+                            progress_start(label=self.label, total_bytes=total_bytes)
+                        with open(tmp_path, "wb") as file_obj:
+                            async for chunk in resp.aiter_bytes(chunk_size=8192):
+                                file_obj.write(chunk)
+                                if callable(progress_advance):
+                                    progress_advance(len(chunk), label=self.label, total_bytes=total_bytes)
+                    os.replace(str(tmp_path), str(self.db_path))
+                    if callable(progress_finish):
+                        progress_finish(label=self.label)
+                    return True, errors
+                except Exception as exc:
+                    tmp_path.unlink(missing_ok=True)
+                    errors.append(f"{url}: {exc}")
+            return False, errors
+        finally:
+            tmp_path.unlink(missing_ok=True)
+
+
+class PreprocessRuntimeProbe:
+    def __init__(self, gui_site_runtime: "GuiSiteRuntime"):
+        self.gui_site_runtime = gui_site_runtime
+
+    async def manga_copy_cache_hit(self) -> bool:
+        runtime = self.gui_site_runtime.create_thread_site_runtime()
+        try:
+            runtime.reqer.get_aes_key()
+            return runtime.reqer.aes_cache_hit()
+        finally:
+            await runtime.aclose()
+
+    async def access_ready(self) -> bool:
+        runtime = self.gui_site_runtime.create_thread_site_runtime()
+        try:
+            test_index = getattr(runtime.reqer, "test_index", None)
+            if not callable(test_index):
+                raise RuntimeError(f"{self.gui_site_runtime.name} preprocess access probe requires reqer.test_index()")
+            return bool(test_index())
+        finally:
+            await runtime.aclose()
+
+    async def verified_runtime(self):
+        runtime = self.gui_site_runtime.create_thread_site_runtime()
+        try:
+            test_index = getattr(runtime.reqer, "test_index", None)
+            if not callable(test_index):
+                raise RuntimeError(f"{self.gui_site_runtime.name} preprocess access probe requires reqer.test_index()")
+            if test_index():
+                return runtime
+        except Exception:
+            await runtime.aclose()
+            raise
+        await runtime.aclose()
+        return None
+
+
 def _domain_cache_hit(gui_site_runtime: "GuiSiteRuntime") -> bool:
     return bool(gui_site_runtime.peek_cached_domain())
 
 
-async def _preprocess_manga_copy(gui_site_runtime: "GuiSiteRuntime", *, conf_state=conf) -> PreprocessResult:
-    runtime = gui_site_runtime.create_thread_site_runtime()
-    reqer = runtime.reqer
-    try:
-        reqer.get_aes_key()
-        cache_hit = reqer.aes_cache_hit()
-    finally:
-        await runtime.aclose()
+async def _preprocess_manga_copy(gui_site_runtime: "GuiSiteRuntime") -> PreprocessResult:
+    cache_hit = await PreprocessRuntimeProbe(gui_site_runtime).manga_copy_cache_hit()
     message = (
         "<br>➖ 缓存处于有效期内，跳过测试"
         if cache_hit else "<br>✅ 拷贝预处理完成"
@@ -125,118 +245,33 @@ async def _preprocess_ehentai(gui_site_runtime: "GuiSiteRuntime", *, conf_state=
             messages=(_message("error", res.EHentai.COOKIES_NOT_SET, channel="infobar"),),
             state_flags={"cookies_ready": False, "access_ready": False})
 
-    runtime = gui_site_runtime.create_thread_site_runtime()
-    access_ready = bool(runtime.reqer.test_index())
+    verified_runtime = await PreprocessRuntimeProbe(gui_site_runtime).verified_runtime()
     provider_index = gui_site_runtime.provider_cls.index
     provider_domain = gui_site_runtime.provider_cls.domain
-    if not access_ready:
-        await runtime.aclose()
+    if verified_runtime is None:
         return PreprocessResult(ready=False, block_search=True,
             messages=(_message("error", res.EHentai.ACCESS_FAIL, channel="custom", url=provider_index, url_name=gui_site_runtime.name),),
             state_flags={"cookies_ready": True, "access_ready": False})
 
     return PreprocessResult(ready=True, domain=provider_domain, runtime_ready=True,
-        messages=(_message("success", "<br>✅ exhentai access pass"),), actions=(_action("attach_ehentai_runtime", runtime=runtime),),
+        messages=(_message("success", "<br>✅ exhentai access pass"),),
+        actions=(_action("attach_ehentai_runtime", runtime=verified_runtime),),
         state_flags={"cookies_ready": True, "access_ready": True})
 
 async def _preprocess_hitomi(
-    gui_site_runtime: "GuiSiteRuntime",
-    *,
-    conf_state=conf,
-    data_client: httpx.AsyncClient,
-    progress_callback=None,
+    gui_site_runtime: "GuiSiteRuntime", *, data_client: httpx.AsyncClient, progress_callback=None,
 ) -> PreprocessResult:
-    runtime = gui_site_runtime.create_thread_site_runtime()
-    try:
-        access_ready = bool(runtime.reqer.test_index())
-    finally:
-        await runtime.aclose()
-    provider_index = gui_site_runtime.provider_cls.index
-    messages: list[dict[str, t.Any]] = []
-    actions: list[dict[str, t.Any]] = []
-    state_flags: dict[str, t.Any] = {"access_ready": access_ready}
-
-    if access_ready:
-        messages.append(_message("success", "<br>✅ hitomi access pass"))
-    else:
-        access_fail_message = _message("error", "", channel="custom", text_key="ACCESS_FAIL", url=provider_index,
-            url_name=gui_site_runtime.name)
-        messages.append(access_fail_message)
-
-    hitomi_db_path = ori_path.joinpath("__temp/hitomi.db")
-    data_ready = hitomi_db_path.exists()
-    if not data_ready:
-        if callable(progress_callback):
-            progress_callback("hitomi db downloading...")
-        messages.append(_message("warning", "⚠️ hitomi db not found, downloading..."))
-        data_ready, download_errors = await _download_hitomi_db(hitomi_db_path, data_client)
-        if download_errors:
-            state_flags["hitomi_db_errors"] = tuple(download_errors)
-        if data_ready:
-            messages.append(_message("success", "<br>✅ hitomi db downloaded"))
-        else:
-            messages.append(_message("error", "<br>❌ hitomi-db download failed"))
-    if data_ready:
-        actions.append(_action("add_hitomi_tool"))
-    state_flags["data_ready"] = data_ready
-
-    return PreprocessResult(ready=access_ready, block_search=False, runtime_ready=access_ready, messages=tuple(messages),
-        actions=tuple(actions), state_flags=state_flags)
+    return await HitomiDatabasePreprocess(gui_site_runtime, data_client, progress_callback).run()
 
 
 async def _preprocess_nhentai(
     gui_site_runtime: "GuiSiteRuntime", *, data_client: httpx.AsyncClient, progress_callback=None
 ) -> PreprocessResult:
-    runtime = gui_site_runtime.create_thread_site_runtime()
-    try:
-        access_ready = bool(runtime.reqer.test_index())
-    finally:
-        await runtime.aclose()
-    provider_index = gui_site_runtime.provider_cls.index
-    messages: list[dict[str, t.Any]] = []
-    state_flags: dict[str, t.Any] = {"access_ready": access_ready}
-
-    if access_ready:
-        messages.append(_message("success", "<br>\u2705 nhentai access pass"))
-    else:
-        messages.append(_message("error", "", channel="custom", text_key="ACCESS_FAIL", url=provider_index, url_name=gui_site_runtime.name))
-
-    db_path = ori_path.joinpath("__temp/nhentai.db")
-    data_ready = db_path.exists()
-    if not data_ready:
-        if callable(progress_callback):
-            progress_callback("nhentai db downloading...")
-        messages.append(_message("warning", "\u26a0\ufe0f nhentai db not found, downloading..."))
-        data_ready, download_errors = await _download_nhentai_db(db_path, data_client)
-        if download_errors:
-            state_flags["nhentai_db_errors"] = tuple(download_errors)
-        if data_ready:
-            messages.append(_message("success", "<br>\u2705 nhentai db downloaded"))
-        else:
-            messages.append(_message("error", "<br>\u274c nhentai-db download failed"))
-    if data_ready:
-        from .nhentai import NhentaiUtils
-
-        try:
-            state_flags["nhentai_tag_catalog_counts"] = NhentaiUtils.preload_tag_catalog(db_path)
-        except Exception as exc:
-            data_ready = False
-            state_flags["nhentai_db_preload_error"] = str(exc)
-            messages.append(_message("error", f"<br>\u274c nhentai tag catalog preload failed: {exc}"))
-        else:
-            messages.append(_message("success", "<br>\u2705 nhentai tag catalog preloaded"))
-    state_flags["data_ready"] = data_ready
-
-    return PreprocessResult(ready=access_ready and data_ready, block_search=False, runtime_ready=access_ready and data_ready,
-        messages=tuple(messages), state_flags=state_flags)
+    return await NhentaiDatabasePreprocess(gui_site_runtime, data_client, progress_callback).run()
 
 
 async def _preprocess_test_index(gui_site_runtime: "GuiSiteRuntime") -> PreprocessResult:
-    runtime = gui_site_runtime.create_thread_site_runtime()
-    try:
-        access_ready = bool(runtime.reqer.test_index())
-    finally:
-        await runtime.aclose()
+    access_ready = await PreprocessRuntimeProbe(gui_site_runtime).access_ready()
     if not access_ready:
         return PreprocessResult(
             ready=False, block_search=True,
@@ -248,53 +283,91 @@ async def _preprocess_test_index(gui_site_runtime: "GuiSiteRuntime") -> Preproce
         messages=(_message("success", f"<br>✅ {gui_site_runtime.name} 访问检测通过"),), state_flags={"access_ready": True})
 
 
-async def _download_hitomi_db(db_path: Path, data_client: httpx.AsyncClient) -> tuple[bool, list[str]]:
-    db_path.parent.mkdir(parents=True, exist_ok=True)
-    urls = (
-        "https://github.com/jasoneri/ComicGUISpider/releases/download/preset/hitomi.db",
-        res.Vars.hitomiDb_tmp_url,
-    )
-    tmp_path = db_path.with_suffix(".db.tmp")
-    errors: list[str] = []
-    try:
-        for url in urls:
-            try:
-                async with data_client.stream("GET", url, follow_redirects=True, timeout=30) as resp:
-                    resp.raise_for_status()
-                    with open(tmp_path, "wb") as file_obj:
-                        async for chunk in resp.aiter_bytes(chunk_size=8192):
-                            file_obj.write(chunk)
-                os.replace(str(tmp_path), str(db_path))
-                return True, errors
-            except Exception as exc:
-                tmp_path.unlink(missing_ok=True)
-                errors.append(f"{url}: {exc}")
-        return False, errors
-    finally:
-        tmp_path.unlink(missing_ok=True)
+class SiteDatabasePreprocess:
+    CACHE_TTL_HOURS = DB_CACHE_TTL_HOURS
+
+    name: str
+    download_urls: tuple[str, ...]
+    data_required = True
+    data_ready_action: str | None = None
+
+    def __init__(self, gui_site_runtime: "GuiSiteRuntime", data_client: httpx.AsyncClient, progress_callback=None):
+        self.gui_site_runtime = gui_site_runtime
+        self.runtime_probe = PreprocessRuntimeProbe(gui_site_runtime)
+        self.asset_cache = ReleaseAssetCache(
+            name=self.name, db_path=ori_path.joinpath(f"__temp/{self.name}.db"), download_urls=self.download_urls,
+            data_client=data_client, progress_callback=progress_callback, timeout=30, cache_ttl_hours=self.CACHE_TTL_HOURS,
+        )
+        self.db_path = self.asset_cache.db_path
+        self.messages: list[dict[str, t.Any]] = []
+        self.actions: list[dict[str, t.Any]] = []
+        self.state_flags: dict[str, t.Any] = {}
+
+    async def run(self) -> PreprocessResult:
+        access_ready = await self.runtime_probe.access_ready()
+        self.state_flags["access_ready"] = access_ready
+        if access_ready:
+            self.messages.append(_message("success", f"<br>✅ {self.name} access pass"))
+        else:
+            self.messages.append(_message("error", "", channel="custom", text_key="ACCESS_FAIL",
+                url=self.gui_site_runtime.provider_cls.index, url_name=self.gui_site_runtime.name))
+
+        asset_result = await self.asset_cache.ensure()
+        data_ready = asset_result.ready
+        self.db_path = asset_result.db_path
+        self.state_flags["cache_hit"] = asset_result.cache_hit
+        self.state_flags["cache_expired"] = asset_result.cache_expired
+        if asset_result.errors:
+            self.state_flags[f"{self.name}_db_errors"] = asset_result.errors
+        if self.state_flags["cache_hit"]:
+            self.messages.append(_message("info", f"➖ {self.name} db 缓存有效，跳过下载"))
+        elif data_ready:
+            self.messages.append(_message("success", f"<br>✅ {self.name} db downloaded"))
+        else:
+            self.messages.append(_message("error", f"<br>❌ {self.name}-db download failed"))
+        if data_ready:
+            data_ready = await self.after_data_ready()
+        if data_ready and self.data_ready_action is not None:
+            self.actions.append(_action(self.data_ready_action))
+        self.state_flags["data_ready"] = data_ready
+
+        ready = access_ready and data_ready if self.data_required else access_ready
+        return PreprocessResult(ready=ready, block_search=False, runtime_ready=ready, messages=tuple(self.messages),
+            actions=tuple(self.actions), state_flags=self.state_flags)
+
+    async def after_data_ready(self) -> bool:
+        return True
 
 
-async def _download_nhentai_db(db_path: Path, data_client: httpx.AsyncClient) -> tuple[bool, list[str]]:
-    db_path.parent.mkdir(parents=True, exist_ok=True)
-    urls = ("https://github.com/jasoneri/ComicGUISpider/releases/download/preset/nhentai.db",)
-    tmp_path = db_path.with_suffix(".db.tmp")
-    errors: list[str] = []
-    try:
-        for url in urls:
-            try:
-                async with data_client.stream("GET", url, follow_redirects=True, timeout=30) as resp:
-                    resp.raise_for_status()
-                    with open(tmp_path, "wb") as file_obj:
-                        async for chunk in resp.aiter_bytes(chunk_size=8192):
-                            file_obj.write(chunk)
-                os.replace(str(tmp_path), str(db_path))
-                return True, errors
-            except Exception as exc:
-                tmp_path.unlink(missing_ok=True)
-                errors.append(f"{url}: {exc}")
-        return False, errors
-    finally:
-        tmp_path.unlink(missing_ok=True)
+class HitomiDatabasePreprocess(SiteDatabasePreprocess):
+    name = "hitomi"
+    download_urls = (HITOMI_ASSET_URL, res.Vars.hitomiDb_tmp_url,)
+    data_required = False
+    data_ready_action = "add_hitomi_tool"
+
+
+class NhentaiDatabasePreprocess(SiteDatabasePreprocess):
+    name = "nhentai"
+    download_urls = (NHENTAI_ASSET_URL,)
+
+    async def after_data_ready(self) -> bool:
+        from .nhentai import NhentaiUtils
+
+        try:
+            self.state_flags["nhentai_tag_catalog_counts"] = NhentaiUtils.preload_tag_catalog(self.db_path)
+        except Exception as exc:
+            self.state_flags["nhentai_db_preload_error"] = str(exc)
+            self.messages.append(_message("error", f"<br>❌ nhentai tag catalog preload failed: {exc}"))
+            return False
+        return True
+
+
+class KemonoReleaseAsset(ReleaseAssetCache):
+    def __init__(self, data_client: httpx.AsyncClient, progress_callback=None):
+        super().__init__(
+            name="kemono", db_path=ori_path.joinpath("__temp/kemono.db"), download_urls=(KEMONO_ASSET_URL,),
+            data_client=data_client, progress_callback=progress_callback, label="kemono db", timeout=60,
+        )
 
 
 async def _preprocess_script(*, data_client: httpx.AsyncClient, progress_callback=None) -> PreprocessResult:
@@ -330,16 +403,18 @@ async def _preprocess_script(*, data_client: httpx.AsyncClient, progress_callbac
     if not services_ready or not dependencies_ready:
         return PreprocessResult(ready=False, block_search=True, messages=tuple(messages), actions=tuple(actions), state_flags=state_flags)
 
-    data_ready, data_cache_hit = await _check_kemono_data(data_client, progress_callback=progress_callback)
-    state_flags["data_ready"] = data_ready
-    state_flags["data_cache_hit"] = data_cache_hit
-    if data_ready:
+    kemono_asset = await KemonoReleaseAsset(data_client, progress_callback).ensure()
+    state_flags["data_ready"] = kemono_asset.ready
+    state_flags["data_cache_hit"] = kemono_asset.cache_hit
+    if kemono_asset.errors:
+        state_flags["kemono_db_errors"] = kemono_asset.errors
+    if kemono_asset.ready:
         messages.append(_message("success", script_res.data_cache_check_success))
         actions.append(_action("open_scriptWin"))
     else:
         messages.append(_message("error", script_res.data_cache_check_failed))
 
-    return PreprocessResult(ready=data_ready, block_search=True, runtime_ready=data_ready, messages=tuple(messages),
+    return PreprocessResult(ready=kemono_asset.ready, block_search=True, runtime_ready=kemono_asset.ready, messages=tuple(messages),
         actions=tuple(actions), state_flags=state_flags)
 
 
@@ -360,30 +435,3 @@ def _check_script_dependencies() -> bool | list[str]:
         except ImportError:
             missing.append(package)
     return True if not missing else missing
-
-
-async def _check_kemono_data(data_client: httpx.AsyncClient, *, progress_callback=None) -> tuple[bool, bool]:
-    def emit_progress(message: str):
-        if callable(progress_callback):
-            progress_callback(message)
-
-    cache = Cache("kemono_data.pkl")
-    await asyncio.to_thread(cache.run, lambda: None, 240)
-    if cache.flag == "validate":
-        return True, True
-
-    emit_progress("正在更新缓存数据...")
-    from utils.script.image.kemono import Api, KemonoAuthor, headers
-
-    async with data_client.stream("GET", Api.creators_txt, headers=headers, follow_redirects=True, timeout=60) as resp:
-        resp.raise_for_status()
-        content = b"".join([chunk async for chunk in resp.aiter_bytes()])
-
-    json_data = json.loads(content.decode("utf-8"))
-    author_dict = {}
-    for item in json_data:
-        author = KemonoAuthor(id=item["id"], name=item["name"], service=item["service"], updated=item["updated"],
-            favorited=item["favorited"])
-        author_dict[author.id] = author
-    await asyncio.to_thread(cache.run, lambda: author_dict, 240, True)
-    return True, False

--- a/utils/website/providers/__init__.py
+++ b/utils/website/providers/__init__.py
@@ -5,5 +5,6 @@ from .ehentai import *
 from .kaobei import *
 from .mangabz import *
 from .jestful import *
-from .hitomi import *
+from ..hitomi import *
 from .hcomic import *
+from ..nhentai import *

--- a/utils/website/providers/hitomi.py
+++ b/utils/website/providers/hitomi.py
@@ -1,1 +1,0 @@
-from utils.website.hitomi import *

--- a/utils/website/site_runtime.py
+++ b/utils/website/site_runtime.py
@@ -45,12 +45,8 @@ class ProviderDescriptor:
     @classmethod
     def create(cls, provider_cls, *, site_index: int | None = None, spider_name: str | None = None) -> "ProviderDescriptor":
         provider_name = str(getattr(provider_cls, "name", "") or spider_name or "")
-        return cls(
-            provider_cls=provider_cls,
-            provider_name=provider_name,
-            spider_name=str(spider_name or provider_name),
-            site_index=site_index,
-        )
+        return cls(provider_cls=provider_cls, provider_name=provider_name, spider_name=str(spider_name or provider_name),
+            site_index=site_index)
 
     def get_uuid(self, *args, **kwargs):
         return self.provider_cls.get_uuid(*args, **kwargs)
@@ -121,11 +117,8 @@ class _ProviderRuntimeBase:
         return normalized
 
     def _require_runtime_domain(self) -> str:
-        domain = _pick_bound_domain(
-            getattr(self.provider, "domain", None),
-            getattr(self.reqer, "domain", None),
-            getattr(self.provider_cls, "domain", None),
-        )
+        domain = _pick_bound_domain(getattr(self.provider, "domain", None), getattr(self.reqer, "domain", None),
+            getattr(self.provider_cls, "domain", None))
         if domain is None:
             raise RuntimeError(
                 f"{self.provider_cls.__name__} spider runtime requires a bound domain on provider/reqer runtime state "
@@ -250,12 +243,7 @@ class GuiSiteRuntime:
         if domain := cls._peek_cached_domain_for(provider_descriptor):
             domains[provider_descriptor.provider_name] = domain
         runtime_context = replace(runtime_context, cookies_by_site=cookies_by_site, domains=domains)
-        return cls(
-            provider_descriptor=provider_descriptor,
-            site_index=site_index,
-            runtime_context=runtime_context,
-            conf_state=conf_state,
-        )
+        return cls(provider_descriptor=provider_descriptor, site_index=site_index, runtime_context=runtime_context, conf_state=conf_state)
 
     @property
     def provider_cls(self):
@@ -299,12 +287,8 @@ class GuiSiteRuntime:
         return temp_p.joinpath(f"{self.name}_domain.txt")
 
     def build_site_config(self) -> PreviewSiteConfig:
-        return PreviewSiteConfig(
-            cookies=self.runtime_context.site_cookies(self.name),
-            domain=self._require_bound_gui_domain(),
-            custom_map=copy.deepcopy(self.runtime_context.custom_map),
-            transport=self.runtime_context.transport,
-        )
+        return PreviewSiteConfig(cookies=self.runtime_context.site_cookies(self.name), domain=self._require_bound_gui_domain(),
+            custom_map=copy.deepcopy(self.runtime_context.custom_map), transport=self.runtime_context.transport)
 
     def build_cover_headers(self, tasks_obj) -> dict[str, str]:
         site_config = self.build_site_config()
@@ -320,12 +304,8 @@ class GuiSiteRuntime:
         return headers
 
     def create_thread_site_runtime(self, *, preview_client: httpx.AsyncClient | None = None) -> ThreadSiteRuntime:
-        return ThreadSiteRuntime(
-            self.provider_descriptor,
-            site_config=self.build_site_config(),
-            conf_state=self.conf_state,
-            preview_client=preview_client,
-        )
+        return ThreadSiteRuntime(self.provider_descriptor, site_config=self.build_site_config(), conf_state=self.conf_state,
+            preview_client=preview_client)
 
     def with_domain(self, domain: str | None) -> "GuiSiteRuntime":
         if not domain:
@@ -337,12 +317,8 @@ class GuiSiteRuntime:
         if next_domains.get(self.name) == normalized:
             return self
         next_domains[self.name] = normalized
-        return GuiSiteRuntime(
-            provider_descriptor=self.provider_descriptor,
-            site_index=self.site_index,
-            runtime_context=replace(self.runtime_context, domains=next_domains),
-            conf_state=self.conf_state,
-        )
+        return GuiSiteRuntime(provider_descriptor=self.provider_descriptor, site_index=self.site_index,
+            runtime_context=replace(self.runtime_context, domains=next_domains), conf_state=self.conf_state)
 
     def persist_domain(self, domain: str) -> "GuiSiteRuntime":
         normalized = _normalize_domain_value(domain)
@@ -351,8 +327,10 @@ class GuiSiteRuntime:
         self.domain_cache_path().write_text(normalized, encoding="utf-8")
         return self.with_domain(normalized)
 
-    def preprocess(self, *, conf_state=conf, data_client=None, progress_callback=None) -> PreprocessResult:
-        return run_site_preprocess(
+    async def preprocess(
+        self, *, conf_state=conf, data_client: httpx.AsyncClient | None = None, progress_callback=None
+    ) -> PreprocessResult:
+        return await run_site_preprocess(
             self.site_index, gui_site_runtime=self, conf_state=conf_state, data_client=data_client, progress_callback=progress_callback
         )
 

--- a/utils/website/site_runtime.py
+++ b/utils/website/site_runtime.py
@@ -330,9 +330,7 @@ class GuiSiteRuntime:
     async def preprocess(
         self, *, conf_state=conf, data_client: httpx.AsyncClient | None = None, progress_callback=None
     ) -> PreprocessResult:
-        return await run_site_preprocess(
-            self.site_index, gui_site_runtime=self, conf_state=conf_state, data_client=data_client, progress_callback=progress_callback
-        )
+        return await run_site_preprocess(self, conf_state=conf_state, data_client=data_client, progress_callback=progress_callback)
 
     def build_browser_environment(self, *, lang: str, cn_proxy_indexes: t.Container[int]) -> BrowserEnvironmentPayload:
         def _browser_domain_required() -> bool:

--- a/variables/__init__.py
+++ b/variables/__init__.py
@@ -19,16 +19,17 @@ class Spider(IntEnum):
     HITOMI = 6       # 🌎 🔞
     H_COMIC = 8      # 🌎 🔞
     JESTFUL = 9      # 🌎
+    NHENTAI = 10     # 🌎 🔞
 
     @property
     def spider_name(self): return self.name.lower()
 
     @classmethod
-    def specials(cls):  return frozenset({cls.JM, cls.WNACG, cls.EHENTAI, cls.HITOMI, cls.H_COMIC})
+    def specials(cls):  return frozenset({cls.JM, cls.WNACG, cls.EHENTAI, cls.HITOMI, cls.H_COMIC, cls.NHENTAI})
     @classmethod
     def mangas(cls):    return frozenset({cls.MANGA_COPY, cls.MANGABZ, cls.JESTFUL})
     @classmethod
-    def cn_proxy(cls):  return frozenset({cls.WNACG, cls.EHENTAI, cls.HITOMI, cls.H_COMIC})
+    def cn_proxy(cls):  return frozenset({cls.WNACG, cls.EHENTAI, cls.HITOMI, cls.H_COMIC, cls.NHENTAI})
     @classmethod
     def aggr(cls):      return frozenset({cls.JM, cls.WNACG, cls.EHENTAI, cls.H_COMIC})   # AggrSearchThread._async_run
     @classmethod
@@ -54,7 +55,8 @@ DEFAULT_COMPLETER = {  # only take effect when init (mean value[completer] of co
     6: ['index-all', 'popular/week-all', 'popular/month-all'],
     7: [],
     8: ['更新'],
-    9: ['更新']
+    9: ['更新'],
+    10: ['更新'],
 }
 STATUS_TIP = {
     0: None,
@@ -66,6 +68,7 @@ STATUS_TIP = {
     6: f"hitomi: {res.GUI.SearchInputStatusTip.hitomi}",
     8: f"h_comic: {res.GUI.SearchInputStatusTip.h_comic}",
     9: f"jestful: {res.GUI.SearchInputStatusTip.jestful}",
+    10: "nhentai",
 }
 
 PYPI_SOURCE = {


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Description
<!-- Write a brief description of the changes introduced by this PR -->

refactor: assets flow

## Related Issues
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Checklist:

* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Have you linted your code locally prior to submission?
* [ ] Have you successfully ran app with your changes locally?

## Summary by Sourcery

为网站集成添加 nhentai 支持，并重构预处理和资源管理。

New Features:
- 引入 nhentai 提供方、解析器、HTTP 客户端以及用于搜索、预览和下载的 GUI 连接。
- 为 nhentai 标签和 kemono 作者添加基于 SQLite 的资源处理流水线，并提供用于构建/更新这些数据库的生成器。
- 在 GUI 流程中支持在预处理完成后排队执行搜索。

Enhancements:
- 重构站点预处理流程，使其异步化、共享 HTTP 客户端构造逻辑，并集中管理 Hitomi、nhentai 和 Kemono 的发布资源缓存。
- 更新 kemono 集成逻辑，从结构化的 SQLite 数据库读取数据，而不是临时的 pickle 缓存。
- 改进异步任务进度上报，加入节流的按字节/百分比的下载进度更新。
- 调整 hitomi 数据库路径和 CI 工作流，以使用临时资源目录和清单（manifest）生成。

Build:
- 修改 hitomi 数据库的 CI 工作流，从 `__temp` 目录而不是 `assets` 目录生成并上传数据库和清单（manifest）。

CI:
- 更新 hitomi-db 的 GitHub Actions 工作流路径，使其匹配基于临时目录的新资源位置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add nhentai support and refactor preprocess and asset management for website integrations.

New Features:
- Introduce nhentai provider, parser, HTTP client, and GUI wiring for search, preview, and downloads.
- Add SQLite-backed asset pipelines for nhentai tags and kemono authors, with generators to build/update these databases.
- Enable queued search execution after preprocess completes in the GUI flow.

Enhancements:
- Refactor site preprocess flow to be async, share HTTP client construction, and centralize release asset caching for Hitomi, nhentai, and Kemono.
- Update kemono integration to read from a structured SQLite database instead of ad-hoc pickle caches.
- Improve async task progress reporting with throttled, byte/percentage-based download progress updates.
- Adjust hitomi DB paths and CI workflow to work with a temp asset directory and manifest generation.

Build:
- Change hitomi DB CI workflow to generate and upload DB and manifest from the __temp directory instead of assets.

CI:
- Update hitomi-db GitHub Actions workflow paths to match the new temp-based asset locations.

</details>