### PR TITLE
build: v2.12.1-beta

### DIFF
--- a/ComicSpider/pipelines.py
+++ b/ComicSpider/pipelines.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
+import inspect
 import os
-import re
 import pathlib
+import re
+import threading
 from io import BytesIO
 from time import sleep
 
@@ -12,10 +14,11 @@ from scrapy import signals
 from scrapy.http import Request, Response
 from scrapy.http.request import NO_CALLBACK
 from scrapy.pipelines.images import ImagesPipeline, ImageException
+from scrapy.utils.defer import deferred_from_coro
 from twisted.internet.defer import maybeDeferred
 from twisted.internet.threads import deferToThread
 
-from utils import conf, TaskObj
+from utils import conf, TaskObj, TasksObj
 from utils.core import sanitize_for_path
 from utils.chore import set_author_ahead
 from utils.website.providers.jm import JmUtils
@@ -112,10 +115,13 @@ class ComicPipeline(ImagesPipeline):
         if tasks_obj and getattr(tasks_obj, 'meta_info', None):
             tasks_obj.meta_info.sv_meta_in(path)
         tasks_obj.local_path = str(path)
-        spider.emit(TasksObjEvent(job_id=getattr(spider, '_job_id', None), task_obj=tasks_obj, is_new=True))
+        self._emit_task(spider, tasks_obj)
         # cache file_folder
         spider.tasks_path[uuid_md5] = path
         return path
+
+    def _emit_task(self, spider, tasks_obj):
+        spider.emit(TasksObjEvent(job_id=getattr(spider, '_job_id', None), task_obj=tasks_obj, is_new=True))
 
     @staticmethod
     def _processed_file_count(stats):
@@ -156,7 +162,13 @@ class ComicPipeline(ImagesPipeline):
 
 
 class CurlComicPipeline(ComicPipeline):
-    """Download uncached images with curl_cffi while retaining ImagesPipeline storage."""
+    """Download uncached images with curl_cffi while retaining ImagesPipeline storage.
+
+    curl_cffi.Session is not safe for concurrent use across deferToThread workers.
+    Scrapy CONCURRENT_REQUESTS fans out many media_to_download calls; a shared
+    session serializes/corrupts completions so ProgressCard jumps in batches.
+    Use one Session per worker thread.
+    """
 
     curl_image_impersonate = "chrome146"
     curl_image_impersonate_fallbacks = ("chrome", "chrome131")
@@ -170,21 +182,66 @@ class CurlComicPipeline(ComicPipeline):
     @classmethod
     def from_crawler(cls, crawler):
         pipe = super().from_crawler(crawler)
-        pipe._curl_session = None
-        pipe._curl_session_config = None
-        crawler.signals.connect(pipe._close_curl_session, signal=signals.spider_closed)
+        pipe._curl_thread_local = threading.local()
+        pipe._curl_sessions_lock = threading.Lock()
+        pipe._curl_all_sessions: list = []
+        pipe._curl_session_identity = None
+        crawler.signals.connect(pipe._close_curl_sessions, signal=signals.spider_closed)
         return pipe
 
     def get_media_requests(self, item, info):
         urls = ItemAdapter(item).get(self.images_urls_field, [])
         return [Request(url, callback=NO_CALLBACK) for url in urls]
 
-    def _close_curl_session(self, spider=None, reason=None):
-        if getattr(self, "_curl_session", None) is None:
-            return
-        self._curl_session.close()
-        self._curl_session = None
-        self._curl_session_config = None
+    @staticmethod
+    def _progress_card_tasks_snapshot(tasks_obj: TasksObj) -> TasksObj:
+        """Metadata-only TasksObj for is_new ProgressCard mount.
+
+        Emitting the live spider.tasks entry shares its downloaded list with the
+        GUI; concurrent curl completions then look like an N-page jump. Snapshot
+        keeps identity/path/cover fields and an empty downloaded list.
+        """
+        snapshot = TasksObj(
+            tasks_obj.taskid,
+            tasks_obj.title,
+            tasks_obj.tasks_count,
+            title_url=getattr(tasks_obj, "title_url", None),
+            episode_name=getattr(tasks_obj, "episode_name", None),
+            cover_url=getattr(tasks_obj, "cover_url", None),
+            meta_info=getattr(tasks_obj, "meta_info", None),
+            source=getattr(tasks_obj, "source", None),
+        )
+        snapshot.local_path = getattr(tasks_obj, "local_path", None)
+        snapshot.cover_bytes = getattr(tasks_obj, "cover_bytes", None)
+        page_name_count = getattr(tasks_obj, "page_name_count", None)
+        if page_name_count is not None:
+            snapshot.page_name_count = page_name_count
+        download_pages = getattr(tasks_obj, "download_pages", None)
+        if download_pages is not None:
+            snapshot.download_pages = download_pages
+        return snapshot
+
+    def _emit_task(self, spider, tasks_obj):
+        spider.emit(TasksObjEvent(
+            job_id=getattr(spider, '_job_id', None),
+            task_obj=self._progress_card_tasks_snapshot(tasks_obj),
+            is_new=True,
+        ))
+
+    def _close_curl_sessions(self, spider=None, reason=None):
+        with self._curl_sessions_lock:
+            sessions = list(self._curl_all_sessions)
+            self._curl_all_sessions.clear()
+            self._curl_session_identity = None
+        for session in sessions:
+            try:
+                session.close()
+            except Exception:
+                pass
+        local = getattr(self, "_curl_thread_local", None)
+        if local is not None:
+            local.session = None
+            local.identity = None
 
     def _resolve_impersonate_candidates(self, spider):
         preferred = getattr(spider, "image_impersonate", None) or self.curl_image_impersonate
@@ -211,23 +268,23 @@ class CurlComicPipeline(ComicPipeline):
             f"expected 'follow_conf', 'proxy', or 'direct'"
         )
 
-    def _get_curl_session(self, spider):
+    def _build_session_identity(self, spider):
         timeout = getattr(spider, "image_download_timeout", self.curl_image_timeout)
         proxy_url = self._resolve_curl_proxy_url(spider)
+        return {
+            "impersonate_candidates": tuple(self._resolve_impersonate_candidates(spider)),
+            "timeout": timeout,
+            "proxy": proxy_url,
+        }
 
-        session_identity = {"impersonate_candidates": self._resolve_impersonate_candidates(spider), "timeout": timeout, "proxy": proxy_url}
-        if getattr(self, "_curl_session_config", None) == session_identity and self._curl_session is not None:
-            return self._curl_session
-
-        self._close_curl_session()
+    def _open_curl_session(self, spider, session_identity):
         last_error = None
         for impersonate_profile in session_identity["impersonate_candidates"]:
-            session_kwargs = {"impersonate": impersonate_profile, "timeout": timeout}
-            if proxy_url:
-                session_kwargs["proxy"] = proxy_url
+            session_kwargs = {"impersonate": impersonate_profile, "timeout": session_identity["timeout"]}
+            if session_identity["proxy"]:
+                session_kwargs["proxy"] = session_identity["proxy"]
             try:
-                self._curl_session = curl_requests.Session(**session_kwargs)
-                self._curl_session_config = session_identity
+                session = curl_requests.Session(**session_kwargs)
                 if impersonate_profile != session_identity["impersonate_candidates"][0]:
                     spider.logger.warning(
                         "%s image curl impersonate fallback | preferred=%s | active=%s",
@@ -235,7 +292,7 @@ class CurlComicPipeline(ComicPipeline):
                         session_identity["impersonate_candidates"][0],
                         impersonate_profile,
                     )
-                return self._curl_session
+                return session
             except Exception as session_error:
                 last_error = session_error
                 spider.logger.warning(
@@ -249,6 +306,31 @@ class CurlComicPipeline(ComicPipeline):
             f"{type(self).__name__} could not create curl session with candidates "
             f"{session_identity['impersonate_candidates']}: {last_error}"
         )
+
+    def _get_curl_session(self, spider):
+        """Per-worker-thread Session; never share across concurrent curl gets."""
+        session_identity = self._build_session_identity(spider)
+        local = self._curl_thread_local
+        if getattr(local, "session", None) is not None and getattr(local, "identity", None) == session_identity:
+            return local.session
+
+        old_session = getattr(local, "session", None)
+        if old_session is not None:
+            with self._curl_sessions_lock:
+                if old_session in self._curl_all_sessions:
+                    self._curl_all_sessions.remove(old_session)
+            try:
+                old_session.close()
+            except Exception:
+                pass
+
+        session = self._open_curl_session(spider, session_identity)
+        local.session = session
+        local.identity = session_identity
+        with self._curl_sessions_lock:
+            self._curl_session_identity = session_identity
+            self._curl_all_sessions.append(session)
+        return session
 
     @property
     def _curl_image_label(self):
@@ -294,6 +376,13 @@ class CurlComicPipeline(ComicPipeline):
             return int(status_code) in retryable_codes
         # Transport / timeout / connection failures have no HTTP status.
         return True
+
+    def _media_downloaded_deferred(self, response, request, info, *, item=None):
+        """Scrapy 2.15 media_downloaded is async; schedule via deferred_from_coro."""
+        result = self.media_downloaded(response, request, info, item=item)
+        if inspect.isawaitable(result):
+            return deferred_from_coro(result)
+        return maybeDeferred(lambda: result)
 
     def media_to_download(self, request: Request, info, *, item=None):
         # super(): local uptodate only (None => need bytes). Never rewrite request.url.
@@ -342,8 +431,7 @@ class CurlComicPipeline(ComicPipeline):
 
             def _handle_curl_result(result):
                 status_code, content = result
-                return maybeDeferred(
-                    self.media_downloaded,
+                return self._media_downloaded_deferred(
                     Response(url=image_url, status=status_code, body=content, request=request),
                     request,
                     info,

--- a/GUI/core/theme/tray.qss
+++ b/GUI/core/theme/tray.qss
@@ -1,4 +1,10 @@
-/* CGS Server tray manage dialog — theme tokens + QSS sections */
+/* CGS Server tray manage dialog — theme tokens + QSS sections
+ *
+ * CRITICAL: Never use broad descendants like `QDialog#ServerManageDialog QLabel`.
+ * qfluent ToolTip / RoundMenu / ComboBoxMenu are parented under the dialog tree
+ * and will inherit those rules → broken day/night flyouts with ghost borders.
+ * Scope every rule to tray-owned objectNames only.
+ */
 
 /* @tokens light */
 PANEL_BG = #ffffff;
@@ -97,9 +103,7 @@ QDialog#ServerManageDialog {
     background: ${PANEL_BG_ALT};
     color: ${TEXT};
 }
-QDialog#ServerManageDialog QLabel {
-    color: ${TEXT};
-}
+/* Named tray labels only — never bare QLabel under the dialog. */
 QLabel#TrayMutedLabel {
     color: ${MUTED};
 }
@@ -240,6 +244,53 @@ QFrame#SchedulePendingCard:hover {
 QFrame#SchedulePendingCard[selected="true"] {
     background: ${CARD_BG_SEL};
 }
+/* Closed ComboBox body only — never style RoundMenu/ComboBoxMenu here. */
+ComboBox#ScheduleBindingCombo,
+ComboBox#ScheduleCatchupCombo {
+    background: ${PANEL_BG};
+    color: ${TEXT};
+    border: 1px solid ${BORDER};
+    border-radius: 6px;
+    padding: 2px 8px;
+}
+/* @endsection */
+
+/* @section tray_context_menu */
+/* Opaque native tray icon menu (QMenu). Must not use RoundMenu translucent shell. */
+QMenu#TrayContextMenu,
+QMenu#TrayContextSubMenu {
+    background-color: ${PANEL_BG};
+    color: ${TEXT};
+    border: 1px solid ${BORDER};
+    border-radius: 6px;
+    padding: 4px;
+}
+QMenu#TrayContextMenu::item,
+QMenu#TrayContextSubMenu::item {
+    background-color: transparent;
+    color: ${TEXT};
+    padding: 6px 28px 6px 12px;
+    border-radius: 4px;
+}
+QMenu#TrayContextMenu::item:selected,
+QMenu#TrayContextSubMenu::item:selected {
+    background-color: ${CARD_BG_SEL};
+    color: ${TEXT};
+}
+QMenu#TrayContextMenu::item:disabled,
+QMenu#TrayContextSubMenu::item:disabled {
+    color: ${MUTED};
+}
+QMenu#TrayContextMenu::separator,
+QMenu#TrayContextSubMenu::separator {
+    height: 1px;
+    background: ${BORDER};
+    margin: 4px 8px;
+}
+QMenu#TrayContextMenu::icon,
+QMenu#TrayContextSubMenu::icon {
+    padding-left: 8px;
+}
 /* @endsection */
 
 /* @section server */
@@ -247,9 +298,6 @@ QFrame#ServerActiveJobPanel {
     background: ${PANEL_BG};
     border: 1px solid ${BORDER};
     border-radius: 6px;
-}
-QFrame#ServerActiveJobPanel QLabel {
-    color: ${TEXT};
 }
 QFrame#ServerTasksPanel,
 QFrame#ServerDiagnosticsPanel {
@@ -262,9 +310,6 @@ QFrame#ServerTaskProgressRow {
     border: 1px solid ${BORDER};
     border-radius: 6px;
 }
-QFrame#ServerTaskProgressRow QLabel {
-    color: ${TEXT};
-}
 QLabel#ServerJobErrorLabel {
     color: ${ERROR_TEXT};
 }
@@ -273,9 +318,6 @@ QLabel#ServerJobErrorLabel {
 /* @section mcp */
 QWidget#McpMonitorTab {
     background: ${MCP_BG};
-}
-QWidget#McpMonitorTab QLabel {
-    color: ${MCP_TEXT};
 }
 QFrame#McpStatusCard {
     background: ${MCP_PANEL_BG_ALT};

--- a/GUI/gui.py
+++ b/GUI/gui.py
@@ -955,6 +955,9 @@ class SpiderGUI(QMainWindow, MitmMainWindow):
             self.preprocess_mgr.cleanup()
         if getattr(self, "preview_mgr", None):
             self.preview_mgr.shutdown()
+        with contextlib.suppress(Exception):
+            from utils.script.aria2 import stop_engine
+            stop_engine()
         event.accept()
         self.destroy()  # 窗口关闭销毁
         if self.dl_mgr is not None:

--- a/GUI/manager/__init__.py
+++ b/GUI/manager/__init__.py
@@ -221,6 +221,7 @@ class Updater:
 
     def to_update(self, ver):
         _UpdateLauncher(ver, installer_manifest=self.proj.installer_manifest).run()
+        # closeEvent is the single lifecycle owner for stop_engine (and other cleanup).
         self.gui.close()
 
 
@@ -263,17 +264,27 @@ class _UpdateLauncher:
 
     def _run_windows_fallback(self):
         ps1_path = exc_p / "updater.ps1"
+        # Same parent-wait contract as deploy/installer (package tree must not be
+        # replaced while this Python process still maps site-packages).
         script = r"""param(
     [Parameter(Mandatory = $true)][string]$UvExe,
     [Parameter(Mandatory = $true)][string]$InstallSpec,
     [Parameter(Mandatory = $true)][string]$IndexUrl,
     [Parameter(Mandatory = $true)][string]$LogPath,
+    [Parameter(Mandatory = $true)][int]$ParentPid,
     [string]$UvToolDir = "",
     [string]$UvToolBinDir = ""
 )
 
 if ($UvToolDir) { $env:UV_TOOL_DIR = $UvToolDir }
 if ($UvToolBinDir) { $env:UV_TOOL_BIN_DIR = $UvToolBinDir }
+
+if ($ParentPid -gt 0) {
+    try {
+        Wait-Process -Id $ParentPid -Timeout 30 -ErrorAction SilentlyContinue
+    } catch {}
+    Start-Sleep -Seconds 1
+}
 
 & $UvExe tool install $InstallSpec --force --index-url $IndexUrl 2>&1 |
     Tee-Object -FilePath $LogPath
@@ -293,6 +304,7 @@ Read-Host "Press Enter to close"
                 "-InstallSpec", self.install_spec,
                 "-IndexUrl", self.index_url,
                 "-LogPath", str(self.log_path),
+                "-ParentPid", str(os.getpid()),
                 "-UvToolDir", os.environ.get("UV_TOOL_DIR", ""),
                 "-UvToolBinDir", os.environ.get("UV_TOOL_BIN_DIR", ""),
             ],

--- a/GUI/tools/subscribe/window.py
+++ b/GUI/tools/subscribe/window.py
@@ -40,6 +40,7 @@ from utils.subscription import (
     ShareCard,
     SubscriptionStore,
     get_active_subscription_customname,
+    remove_yaml_book,
     set_active_subscription_customname,
 )
 from utils.subscription.library import LocalLibraryStore
@@ -738,7 +739,7 @@ class SubscribeWindow(FramelessWindow):
         self._sync_card_conf_panel(key)
 
     def _on_card_delete_requested(self, card_key: str) -> None:
-        """delBtn: drop library favorite (library SSoT) + remove card from waterfall."""
+        """Delete the yml schedule row and library join, then drop the card."""
         key = str(card_key or "")
         board = self.library_board
         if board is None:
@@ -746,14 +747,31 @@ class SubscribeWindow(FramelessWindow):
         card = board.cards_by_key.get(key)
         if card is None:
             return
+        site_index = int(card.site_index)
         book_url = LocalLibraryStore.book_unique_url(card.book)
+        site_name = LocalLibraryStore.book_site(card.book, site_index=site_index)
         title = LocalLibraryStore.book_title(card.book) or key
-        try:
-            if book_url:
-                self.library.remove_url(int(card.site_index), book_url)
-        except Exception as exc:
-            self._show_error(str(exc))
+        if not book_url:
+            self._show_error(f"无法删除订阅：缺少书目 URL · {title}")
             return
+
+        try:
+            yaml_removed = remove_yaml_book(self.config, site_name, book_url)
+            if yaml_removed:
+                self.store.save(self.config)
+            library_removed = self.library.remove_url(site_index, book_url)
+        except Exception as error:
+            self._show_error(f"删除订阅失败 · {error}")
+            return
+        if not yaml_removed and not library_removed:
+            # Stale card only: no persistence row claimed this delete.
+            if self._selected_card_key == key:
+                self._selected_card_key = None
+                self._sync_card_conf_panel(None)
+            board.remove_card(key)
+            board.show_empty_after_delete(self.library_count_label)
+            return
+
         if self._selected_card_key == key:
             self._selected_card_key = None
             self._sync_card_conf_panel(None)
@@ -761,7 +779,7 @@ class SubscribeWindow(FramelessWindow):
         board.show_empty_after_delete(self.library_count_label)
         InfoBar.success(
             title="",
-            content=f"已取消订阅 · {title}",
+            content=f"已删除订阅 · {title}",
             orient=Qt.Horizontal,
             position=InfoBarPosition.BOTTOM,
             duration=2200,
@@ -776,17 +794,14 @@ class SubscribeWindow(FramelessWindow):
             self._show_error(str(exc))
 
     def _show_error(self, message: str) -> None:
-        try:
-            InfoBar.error(
-                title="",
-                content=message,
-                orient=Qt.Horizontal,
-                position=InfoBarPosition.BOTTOM,
-                duration=5000,
-                parent=self,
-            )
-        except Exception:
-            pass
+        InfoBar.error(
+            title="",
+            content=message,
+            orient=Qt.Horizontal,
+            position=InfoBarPosition.BOTTOM,
+            duration=5000,
+            parent=self,
+        )
 
     def _import_preview_books_from_button(self) -> None:
         def action() -> None:

--- a/GUI/tray/app.py
+++ b/GUI/tray/app.py
@@ -22,7 +22,13 @@ from PySide6.QtWidgets import (
 from qfluentwidgets import Action, FluentIcon as FIF
 
 from utils.tray.event_log import TrayEventLog
-from utils.tray.subscription_scheduler import ScheduleDecision, ScheduleStatus, SubscriptionScheduler, default_scheduler_state_path
+from utils.tray.subscription_scheduler import (
+    ScheduleDecision,
+    ScheduleStatus,
+    SubscriptionScheduler,
+    default_scheduler_state_path,
+    schedule_run_scope,
+)
 from utils.tray.subscription_runner import SubscriptionRunner, SubscriptionRunSummary
 
 
@@ -145,9 +151,12 @@ class TrayApp(QObject):
         if self._run_thread is not None and self._run_thread.is_alive():
             self.event_log.append("subscription", result="skip", detail="subscription run already in progress")
             return False
-        trigger = "schedule" if decision is not None else "manual"
+        trigger, selected_books = schedule_run_scope(detail, decision)
         self._run_thread = threading.Thread(
-            target=self._run_subscription_once, args=(trigger,), name="CGSSubscriptionRunNow", daemon=True
+            target=self._run_subscription_once,
+            args=(trigger, selected_books),
+            name="CGSSubscriptionRunNow",
+            daemon=True,
         )
         try:
             self._run_thread.start()
@@ -175,9 +184,16 @@ class TrayApp(QObject):
             return
         self._update_tray_tooltip()
 
-    def _run_subscription_once(self, trigger: str = "schedule") -> None:
+    def _run_subscription_once(
+        self,
+        trigger: str = "schedule",
+        selected_books: Optional[tuple] = None,
+    ) -> None:
         try:
-            summary = self._runner.run_once(trigger=trigger)
+            summary = self._runner.run_once(
+                trigger=trigger,
+                selected_books=selected_books,
+            )
         except Exception as exc:
             self._run_failed.emit(exc)
             return

--- a/deploy/__init__.py
+++ b/deploy/__init__.py
@@ -19,14 +19,6 @@ class Env:
         os.environ['QT_QPA_PLATFORM_PLUGIN_PATH'] = str(
             proj_path.parent.joinpath(r"site-packages\PyQt5\Qt5\plugins\platforms"))
 
-    @property
-    def aira2(self) -> pathlib.Path:
-        """Local aria2c path under __temp/aira2 (preset-sourced; not PATH).
-
-        Uses proj_path/__temp (same tree as utils.temp_p) without importing utils,
-        to avoid deploy ↔ utils circular import.
-        """
-        return self.proj_p.joinpath("__temp", "aira2", self.aira2_binary_name)
 
     def env_init(self):
         ...

--- a/deploy/launcher/mac/__init__.py
+++ b/deploy/launcher/mac/__init__.py
@@ -21,10 +21,6 @@ class macOS:
     def __init__(self, _p):
         self.proj_p = _p
 
-    @property
-    def aira2(self) -> pathlib.Path:
-        # Same tree as utils.temp_p; avoid importing utils (deploy ↔ utils cycle).
-        return pathlib.Path(self.proj_p).joinpath("__temp", "aira2", self.aira2_binary_name)
 
     @staticmethod
     def open_folder(_p):

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -6,7 +6,7 @@ import { markdownUrlReplacePlugin } from './plugins/markdown-url-replace';
 import { createDocsUrlConfig } from './shared/urls';
 
 
-const version = `v2.12.0`
+const version = `v2.12.1-beta`
 const docsRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
 const docsEnv = loadEnv('', docsRoot, '')
 const { URLS, PLACEHOLDER_MAP } = createDocsUrlConfig(docsEnv)

--- a/docs/_github/release_notes.md
+++ b/docs/_github/release_notes.md
@@ -15,13 +15,17 @@
 + script 选择时会默认下载 aira2 代替此前的 motrix 前置需求，具体[参阅文档](https://cgs.101114105.xyz/script/#%E2%9A%A0%EF%B8%8F-%E9%80%9A%E7%94%A8%E5%89%8D%E7%BD%AE%E9%A1%BB%E7%9F%A5)
 + 追加登录模块，支持 jm/ehentai/mangabz/nhentai/manhuagui/dm5/comicabc，点按钮进官方登录页右键保存 cookies 到本地，实际使用仍在试行中仅支持一些线上收藏预览的功能，不保证可用
 + 引入公告系统，当前有个问卷调查
-+ 本地收藏与订阅触发一致（漫画卡封面右上），[订阅管理面板](https://cgs.101114105.xyz/feat/#_4-%E8%AE%A2%E9%98%85%E7%AE%A1%E7%90%86%E9%9D%A2%E6%9D%BF-%E8%AF%95%E8%A1%8C%E4%B8%AD)已独立，入口设在 rvTool 的右下按钮，订阅功能视为试行状态
++ 本地收藏与订阅触发一致（漫画卡封面右上），[订阅管理面板](https://cgs.101114105.xyz/feat/#_4-%E8%AE%A2%E9%98%85%E7%AE%A1%E7%90%86%E9%9D%A2%E6%9D%BF-%E8%AF%95%E8%A1%8C%E4%B8%AD)已独立，入口设在 rvTool 的右下按钮
++ ✨ 配合订阅管理，托盘调度已测试自动下载 > 本地最新
 
 ## 🐞 Fix/Upd
 
 + danbooru 若干交互修复
-+ wnacg 图源下载优化，dm5 图源下载优化
++ ✨ wnacg 代理不受国内域名影响修复，进度条跟进修复
++ ✨ nh 的启动探针环境测试修复，jestful 封面加载修复
++ dm5 图源下载优化
 + 冷启动优化
 + 修复 jcomic 图源下载
 + 优化 win int 的更新相关
++ ✨ aria2 二进制改存用户配置目录
 + `C108` , on! (更新了默认)

--- a/docs/changelog/history.md
+++ b/docs/changelog/history.md
@@ -1,6 +1,6 @@
 # 🕑 更新历史
 
-## `v2.12.0`
+## `v2.12.1-beta`
 
 ### 🎁 Features
 
@@ -19,15 +19,19 @@
 + script 选择时会默认下载 aira2 代替此前的 motrix 前置需求，具体[参阅文档](https://cgs.101114105.xyz/script/#%E2%9A%A0%EF%B8%8F-%E9%80%9A%E7%94%A8%E5%89%8D%E7%BD%AE%E9%A1%BB%E7%9F%A5)
 + 追加登录模块，支持 jm/ehentai/mangabz/nhentai/manhuagui/dm5/comicabc，点按钮进官方登录页右键保存 cookies 到本地，实际使用仍在试行中仅支持一些线上收藏预览的功能，不保证可用
 + 引入公告系统，当前有个问卷调查
-+ 本地收藏与订阅触发一致（漫画卡封面右上），[订阅管理面板](https://cgs.101114105.xyz/feat/#_4-%E8%AE%A2%E9%98%85%E7%AE%A1%E7%90%86%E9%9D%A2%E6%9D%BF-%E8%AF%95%E8%A1%8C%E4%B8%AD)已独立，入口设在 rvTool 的右下按钮，订阅功能视为试行状态
++ 本地收藏与订阅触发一致（漫画卡封面右上），[订阅管理面板](https://cgs.101114105.xyz/feat/#_4-%E8%AE%A2%E9%98%85%E7%AE%A1%E7%90%86%E9%9D%A2%E6%9D%BF-%E8%AF%95%E8%A1%8C%E4%B8%AD)已独立，入口设在 rvTool 的右下按钮
++ ✨ 配合订阅管理，托盘调度已测试自动下载 > 本地最新
 
 ### 🐞 Fix/Upd
 
 + danbooru 若干交互修复
-+ wnacg 图源下载优化，dm5 图源下载优化
++ ✨ wnacg 代理不受国内域名影响修复，进度条跟进修复
++ ✨ nh 的启动探针环境测试修复，jestful 封面加载修复
++ dm5 图源下载优化
 + 冷启动优化
 + 修复 jcomic 图源下载
 + 优化 win int 的更新相关
++ ✨ aria2 二进制改存用户配置目录
 + `C108` , on! (更新了默认)
 
 ::: tip 备用更新方法  
@@ -51,7 +55,7 @@ mac/终端uv：如上下载 {tag}.zip，解压目录直接跑 `uv run CGS.py`
 
 ::: details v2.11.0
 
-+ ✨CGS server/mcp ，由配置窗口点击 `CGS server` 触发托盘，配合 [rv-app](https://rv.101114105.xyz/guide/mobile.html) 使用
++ CGS server/mcp ，由配置窗口点击 `CGS server` 触发托盘，配合 [rv-app](https://rv.101114105.xyz/guide/mobile.html) 使用
 + 自定义站点选择框支持显示/隐藏
 + discord 分享模块
 + Danbooru 支持 视频播放下载，zip下载，扩展按键绑定

--- a/docs/script/index.md
+++ b/docs/script/index.md
@@ -5,8 +5,8 @@ danbooru / kemono / cbg / saucenao
 
 ## ⚠️ 通用前置须知
 
-::: tip 🔔 v2.12.0 起，选择 script 时会自动下载 aira2 二进制执行文件 [link](https://github.com/jasoneri/ComicGUISpider/releases/tag/preset)
-Script 设置中 aira2 有单独代理设置
+::: tip 🔔 v2.12.0 起，选择 script 时会自动下载 aria2 二进制执行文件 [link](https://github.com/jasoneri/ComicGUISpider/releases/tag/preset)
+Script 设置中 aria2 有单独代理设置
 :::
 ::: info 脚本集通用前置安装( v2.11.0 改为 `按需` )
 任务模块：[Redis-windows](https://github.com/redis-windows/redis-windows/releases) | mac:`brew install redis`  

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ComicGUISpider"
-version = "2.12.0"
+version = "2.12.1-beta"
 description = "GUI Comic Downloader"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/server/api.py
+++ b/server/api.py
@@ -194,7 +194,7 @@ def create_app(surfaces: Iterable[ServerSurface] = (), *, auth_token: str | None
         require_auth(authorization)
         try:
             return load_subscription_config(SubscriptionStore(customname))
-        except (TypeError, ValueError) as exc:
+        except (TypeError, ValueError, RuntimeError) as exc:
             _raise_subscription_error(exc)
 
     @app.put("/subscription/config")

--- a/server/main.py
+++ b/server/main.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import sys
 
 from utils.server_control import (
@@ -14,16 +15,27 @@ from utils.server_control import (
 )
 from variables import VER
 
+# Parent ServerLauncher sets this so the child never "resolve existing → exit 0"
+# without publishing its own tray discovery (that race is what users see as
+# "cgs-server exited with code 0; discovery: no tray-hosted record").
+_FORCE_HOST_ENV = "CGS_SERVER_FORCE_HOST"
+
+
+def _env_flag(name: str) -> bool:
+    return str(os.environ.get(name) or "").strip().casefold() in {"1", "true", "yes", "on"}
+
 
 def main() -> int:
     configure_server_launch_logging()
     if len(sys.argv) > 1:
         raise SystemExit("cgs-server does not accept startup parameters")
 
-    endpoint = ServerLauncher(timeout=1.0).resolve_existing()
-    if endpoint is not None:
-        sync_redviewer_server_endpoint(endpoint)
-        return 0
+    force_host = _env_flag(_FORCE_HOST_ENV)
+    if not force_host:
+        endpoint = ServerLauncher(timeout=1.0).resolve_existing()
+        if endpoint is not None:
+            sync_redviewer_server_endpoint(endpoint)
+            return 0
 
     from server.tray.host import ServerTrayHost
 

--- a/server/subscription.py
+++ b/server/subscription.py
@@ -19,8 +19,9 @@ from utils.subscription import (
     SubscriptionConfig,
     SubscriptionStore,
     normalize_tz_offset,
+    remove_yaml_book,
 )
-from utils.subscription.library import LocalLibraryStore
+from utils.subscription.library import LibraryBookView, LocalLibraryStore
 from utils.subscription.site_proxy import normalize_site_proxy_map
 from variables import CGS_DISCORD_SHARE_API, CGS_METADATA_CHANNEL_ID
 
@@ -38,43 +39,50 @@ def save_subscription_config(store: SubscriptionStore, payload: dict[str, Any]) 
 def add_book(store: SubscriptionStore, payload: dict[str, Any]) -> dict[str, Any]:
     entry = _book_from_payload(payload)
     library = LocalLibraryStore()
-    site_index = library.site_index_for_name(entry.site)
-    if site_index is None:
+    if library.site_index_for_name(entry.site) is None:
         raise ValueError(f"unknown subscription book site: {entry.site}")
-    from utils.website.info import BookInfo
-    book = BookInfo(id=entry.url, source=entry.site, url=entry.url, preview_url=entry.url, name=entry.title)
-    if not library.add_book(site_index, book):
+    config = store.load()
+    if any((book.site, book.url) == (entry.site, entry.url) for book in config.books):
         raise ValueError(f"subscription book already exists: {entry.url}")
+    config.books.append(entry)
+    store.save(config)
     return subscription_config_payload(store.load())
 
 
 def update_book(store: SubscriptionStore, index: int, payload: dict[str, Any]) -> dict[str, Any]:
     library = LocalLibraryStore()
-    entries = library.book_entries()
-    book = _indexed(entries, index, "subscription book")
+    config = store.load()
+    book = _indexed(config.books, index, "subscription book")
     next_book = BookEntry(
         site=_optional_text(payload, "site", book.site),
         url=_optional_text(payload, "url", book.url),
         title=_optional_text(payload, "title", book.title),
-        enabled=True,
+        enabled=_optional_bool(payload, "enabled", book.enabled),
+        check=book.check.copy() if book.check is not None else None,
     )
     _validate_book(next_book)
-    library.remove_entry(book)
-    site_index = library.site_index_for_name(next_book.site)
-    if site_index is None:
+    if library.site_index_for_name(next_book.site) is None:
         raise ValueError(f"unknown subscription book site: {next_book.site}")
-    from utils.website.info import BookInfo
-    info = BookInfo(id=next_book.url, source=next_book.site, url=next_book.url, preview_url=next_book.url, name=next_book.title)
-    if not library.add_book(site_index, info):
+    if any(
+        item_index != index and (item.site, item.url) == (next_book.site, next_book.url)
+        for item_index, item in enumerate(config.books)
+    ):
         raise ValueError(f"subscription book already exists: {next_book.url}")
+    config.books[index] = next_book
+    store.save(config)
     return subscription_config_payload(store.load())
 
 
 def remove_book(store: SubscriptionStore, index: int) -> dict[str, Any]:
     library = LocalLibraryStore()
-    entries = library.book_entries()
-    entry = _indexed(entries, index, "subscription book")
-    library.remove_entry(entry)
+    config = store.load()
+    entry = _indexed(config.books, index, "subscription book")
+    if not remove_yaml_book(config, entry.site, entry.url):
+        raise RuntimeError(f"yaml books[] remove failed: {entry.url}")
+    store.save(config)
+    site_index = library.site_index_for_name(entry.site)
+    if site_index is not None:
+        library.remove_entry(entry)
     return subscription_config_payload(store.load())
 
 
@@ -110,7 +118,7 @@ async def publish_subscription_share_card(store: SubscriptionStore) -> dict[str,
     cfg = store.load()
     if cfg.publish is not None and cfg.publish.share_card and cfg.publish.share_card.posted_at:
         raise ValueError("share_card already published")
-    enabled_books = LocalLibraryStore().book_entries()
+    enabled_books = [entry for entry in cfg.books if entry.enabled]
     if not enabled_books:
         raise ValueError("at least one enabled subscription book is required before publishing share_card")
 
@@ -148,7 +156,19 @@ async def publish_subscription_share_card(store: SubscriptionStore) -> dict[str,
 
 
 def subscription_config_payload(cfg: SubscriptionConfig) -> dict[str, Any]:
-    library_books = LocalLibraryStore().book_entries(yaml_books=cfg.books)
+    library = LocalLibraryStore()
+    joined_entries = library.book_entries(yaml_books=cfg.books)
+    joined_by_key = {
+        LibraryBookView.entry_key(entry.site, entry.url): entry
+        for entry in joined_entries
+    }
+    library_books = [
+        joined_by_key.get(
+            LibraryBookView.entry_key(book.site, book.url),
+            book,
+        )
+        for book in cfg.books
+    ]
     return {
         "customname": cfg.customname,
         "books": [asdict(book) for book in library_books],

--- a/server/tray/dialog.py
+++ b/server/tray/dialog.py
@@ -7,7 +7,7 @@ from PySide6.QtWidgets import QApplication, QStackedWidget, QVBoxLayout, QWidget
 from qfluentwidgets import SegmentedWidget, qconfig
 
 from GUI.core.theme import theme_mgr
-from server.tray.style import build_dialog_stylesheet
+from server.tray.style import apply_manage_dialog_theme
 from server.tray.ui_common import ServerManageDialog, configure_tray_qt_fonts
 from utils.config import qconfig_dir
 from utils.config.qc import cgs_cfg
@@ -87,7 +87,7 @@ class ManageDialogController:
         from GUI.core.theme.qss_template import load_templated_qss_document
 
         load_templated_qss_document.cache_clear()
-        self.dialog.setStyleSheet(build_dialog_stylesheet())
+        apply_manage_dialog_theme(self.dialog)
         if self.is_visible():
             self.refresh(rebuild_lists=True)
 

--- a/server/tray/host.py
+++ b/server/tray/host.py
@@ -27,6 +27,7 @@ from PySide6.QtWidgets import (
 )
 from qfluentwidgets import Action, FluentIcon as FIF
 
+from GUI.core.theme import theme_mgr
 from utils.server_control import (
     DEFAULT_SERVER_BIND_HOST,
     DEFAULT_SERVER_MCP_PATH,
@@ -52,11 +53,18 @@ from utils.tray.notification_policy import (
     notification_for_schedule_result,
 )
 from utils.tray.schedule_presentation import ScheduleCache, SchedulePresentation, build_schedule_presentation
-from utils.tray.subscription_scheduler import ScheduleDecision, ScheduleStatus, SubscriptionScheduler, default_scheduler_state_path
+from utils.tray.subscription_scheduler import (
+    ScheduleDecision,
+    ScheduleStatus,
+    SubscriptionScheduler,
+    default_scheduler_state_path,
+    schedule_run_scope,
+)
 from server.tray.dialog import ManageDialogController
 from server.tray.mcp_panel import McpPanel
 from server.tray.schedule_panel import SchedulePanel
 from server.tray.server_panel import ServerPanel
+from server.tray.style import apply_tray_context_menu_theme
 from server.tray.ui_common import (
     ServerManageDialog,
     TrayUiContext,
@@ -166,6 +174,7 @@ class ServerTrayHost(QObject):
         self.schedule_finished.connect(self._on_schedule_finished)
         self.schedule_failed.connect(self._on_schedule_failed)
         self.schedule_progress.connect(self._on_schedule_progress)
+        theme_mgr.subscribe(self._apply_tray_theme)
 
     @property
     def manage_dialog(self) -> ServerManageDialog | None:
@@ -274,19 +283,46 @@ class ServerTrayHost(QObject):
         self._on_schedule_tick()
 
     def _build_menu(self) -> QMenu:
+        # Native QMenu only (see tray-menu-notification-probe). RoundMenu uses
+        # WA_TranslucentBackground + outer margins for shadow → ghost chrome ring
+        # on the system-tray surface. Day/night is applied by the tray style owner.
         self.menu = QMenu("CGS Server")
-        manage_action = Action(FIF.APPLICATION, text="管理面板", parent=self, triggered=lambda _checked=False: self.show_manage_dialog())
+        self.menu.setObjectName("TrayContextMenu")
+        self.menu.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground, False)
+
+        manage_action = Action(
+            FIF.APPLICATION,
+            text="管理面板",
+            parent=self,
+            triggered=lambda _checked=False: self.show_manage_dialog(),
+        )
         self.menu.addAction(manage_action)
 
         schedule_menu = QMenu("Schedule", self.menu)
-        run_now = Action(FIF.PLAY, text="立刻执行", parent=self, triggered=lambda _checked=False: self.run_schedule_now())
+        schedule_menu.setObjectName("TrayContextSubMenu")
+        schedule_menu.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground, False)
+        run_now = Action(
+            FIF.PLAY,
+            text="立刻执行",
+            parent=self,
+            triggered=lambda _checked=False: self.run_schedule_now(),
+        )
         schedule_menu.addAction(run_now)
         self.menu.addMenu(schedule_menu)
 
         self.menu.addSeparator()
-        quit_action = Action(FIF.POWER_BUTTON, text="退出", parent=self, triggered=lambda _checked=False: self.shutdown())
+        quit_action = Action(
+            FIF.POWER_BUTTON,
+            text="退出",
+            parent=self,
+            triggered=lambda _checked=False: self.shutdown(),
+        )
         self.menu.addAction(quit_action)
+        apply_tray_context_menu_theme(self.menu)
         return self.menu
+
+    def _apply_tray_theme(self, _theme=None) -> None:
+        apply_tray_context_menu_theme(self.menu)
 
     @Slot(QSystemTrayIcon.ActivationReason)
     def _on_tray_activated(self, reason: QSystemTrayIcon.ActivationReason) -> None:
@@ -486,9 +522,12 @@ class ServerTrayHost(QObject):
             self._show_schedule_notification(notification_for_schedule_blocker(blocker, trigger=detail))
             self.refresh_status(schedule_full=True)
             return False
-        trigger = "schedule" if decision is not None else "manual"
+        trigger, selected_books = schedule_run_scope(detail, decision)
         self.schedule.run_thread = threading.Thread(
-            target=self._run_schedule_once, args=(detail, trigger), name="CGSServerScheduleRun", daemon=True
+            target=self._run_schedule_once,
+            args=(detail, trigger, selected_books),
+            name="CGSServerScheduleRun",
+            daemon=True,
         )
         try:
             self.schedule.run_thread.start()
@@ -515,7 +554,12 @@ class ServerTrayHost(QObject):
             return self.ui.redact("CGS Server runtime is unavailable")
         return ""
 
-    def _run_schedule_once(self, detail: str, trigger: str) -> None:
+    def _run_schedule_once(
+        self,
+        detail: str,
+        trigger: str,
+        selected_books: tuple | None = None,
+    ) -> None:
         try:
             from utils.subscription import get_active_subscription_customname
             from utils.tray.subscription_runner import SubscriptionRunner
@@ -530,7 +574,10 @@ class ServerTrayHost(QObject):
                 progress_callback=self.schedule_progress.emit,
             )
             try:
-                summary = runner.run_once(trigger=trigger)
+                summary = runner.run_once(
+                    trigger=trigger,
+                    selected_books=selected_books,
+                )
                 summary.trigger = detail
             finally:
                 runner.shutdown()
@@ -580,6 +627,7 @@ class ServerTrayHost(QObject):
         if self.shutdown_requested:
             return
         self.shutdown_requested = True
+        theme_mgr.unsubscribe(self._apply_tray_theme)
         self._restore_exception_hooks()
         if self.status_timer is not None:
             self.status_timer.stop()

--- a/server/tray/mcp_panel.py
+++ b/server/tray/mcp_panel.py
@@ -19,7 +19,7 @@ from qfluentwidgets import (
 )
 
 from server.tray.style import chip_stylesheet, mcp_heading_stylesheet, mcp_muted_label_stylesheet
-from server.tray.ui_common import tray_mono_font
+from server.tray.ui_common import install_tray_fluent_tooltip, tray_mono_font
 from utils.server_control import DEFAULT_SERVER_MCP_PATH, server_launch_log_path
 from GUI.uic.qfluent.components.icons import CgsIcon
 
@@ -179,6 +179,7 @@ class McpPanel:
             for column in range(self.tools_table.columnCount()):
                 item = self.tools_table.item(row, column)
                 if item is not None:
+                    # QTableWidgetItem tooltip is native Qt; full name is also on the line edit.
                     item.setToolTip(name)
         if rows and self.capability_name_line is not None and not self.capability_name_line.text():
             self._set_capability_name(rows[0][0])
@@ -220,7 +221,7 @@ class McpPanel:
         clear_button.setObjectName("McpCallLogClearButton")
         clear_button.clicked.connect(lambda _checked=False: self._clear_call_log())
         restart_button = TransparentToolButton(CgsIcon.REBOOT, band)
-        restart_button.setToolTip("重启")
+        install_tray_fluent_tooltip(restart_button, "重启")
         restart_button.clicked.connect(lambda _checked=False: self.host.restart_server_surface())
         layout.addWidget(debug_label)
         layout.addWidget(self.debug_switch)
@@ -295,7 +296,7 @@ class McpPanel:
         text.setStyleSheet(mcp_muted_label_stylesheet())
         button = TransparentToolButton(FIF.COPY, row)
         button.setFixedSize(24, 24)
-        button.setToolTip(f"复制 {label}")
+        install_tray_fluent_tooltip(button, f"复制 {label}")
         button.clicked.connect(lambda _checked=False, value=copy_value: self.host.ui.copy_to_clipboard(value))
         layout.addWidget(text, 1)
         layout.addWidget(button)
@@ -334,7 +335,7 @@ class McpPanel:
         self.capability_name_line.setPlaceholderText("Select a capability to view the full name")
         self.capability_copy_button = TransparentToolButton(FIF.COPY, selected)
         self.capability_copy_button.setObjectName("McpCapabilityNameCopyButton")
-        self.capability_copy_button.setToolTip("复制完整 Name")
+        install_tray_fluent_tooltip(self.capability_copy_button, "复制完整 Name")
         self.capability_copy_button.clicked.connect(lambda _checked=False: self._copy_capability_name())
         selected_layout.addWidget(self.capability_name_line, 1)
         selected_layout.addWidget(self.capability_copy_button)
@@ -393,7 +394,7 @@ class McpPanel:
         header.addStretch(1)
         copy_button = TransparentToolButton(FIF.COPY, drawer)
         copy_button.setObjectName("McpDebugCopyButton")
-        copy_button.setToolTip("复制已脱敏 MCP debug 内容")
+        install_tray_fluent_tooltip(copy_button, "复制已脱敏 MCP debug 内容")
         copy_button.clicked.connect(lambda _checked=False: self._copy_debug_text())
         header.addWidget(copy_button)
         layout.addLayout(header)
@@ -418,7 +419,7 @@ class McpPanel:
         self.auth_line.setViewPasswordButtonVisible(True)
         self.auth_copy_button = TransparentToolButton(FIF.COPY, widget)
         self.auth_copy_button.setObjectName("McpAuthCopyButton")
-        self.auth_copy_button.setToolTip("复制 Auth token")
+        install_tray_fluent_tooltip(self.auth_copy_button, "复制 Auth token")
         self.auth_copy_button.clicked.connect(lambda _checked=False: self.host.ui.copy_to_clipboard(self.host.record.token))
         layout.addWidget(self.auth_line, 1)
         layout.addWidget(self.auth_copy_button)
@@ -456,7 +457,7 @@ class McpPanel:
     def _set_capability_name(self, name: str) -> None:
         if self.capability_name_line is not None:
             self.capability_name_line.setText(name)
-            self.capability_name_line.setToolTip(name)
+            install_tray_fluent_tooltip(self.capability_name_line, name)
 
     def _copy_capability_name(self) -> None:
         if self.capability_name_line is not None:

--- a/server/tray/schedule_panel.py
+++ b/server/tray/schedule_panel.py
@@ -7,7 +7,8 @@ from dataclasses import asdict, dataclass
 from typing import TYPE_CHECKING
 
 from PySide6.QtCore import Qt
-from PySide6.QtWidgets import QFrame, QGridLayout, QHBoxLayout, QLabel, QScrollArea, QStackedWidget, QVBoxLayout, QWidget
+from PySide6.QtGui import QFontMetrics
+from PySide6.QtWidgets import QFrame, QGridLayout, QHBoxLayout, QLabel, QScrollArea, QSizePolicy, QStackedWidget, QVBoxLayout, QWidget
 from qfluentwidgets import (
     BodyLabel,
     CaptionLabel,
@@ -30,6 +31,7 @@ from server.tray.style import (
     body_text_stylesheet,
     cover_placeholder_stylesheet,
     detail_title_stylesheet,
+    install_tray_combo_menu_hardening,
     latest_banner_stylesheet,
     muted_label_stylesheet,
     pending_card_stylesheet,
@@ -43,6 +45,7 @@ from server.tray.ui_common import (
     ClickableFrame,
     StageRail,
     clear_layout,
+    install_tray_fluent_tooltip,
     tray_mono_font,
 )
 from utils.tray.schedule_presentation import SchedulePresentation
@@ -81,6 +84,9 @@ class SchedulePanel:
         self.debug_enabled = False
         self.plan_layout: QGridLayout | None = None
         self.cache_chip: QLabel | None = None
+        self.binding_combo: ComboBox | None = None
+        self.catchup_combo: ComboBox | None = None
+        self._binding_combo_guard = False
         self.sources_segment: SegmentedWidget | None = None
         self.sources_stack: QStackedWidget | None = None
         self.sources_layout: QVBoxLayout | None = None
@@ -95,16 +101,25 @@ class SchedulePanel:
         self.run_meta_label: QLabel | None = None
         self.stage_rail: StageRail | None = None
         self.latest_banner: QLabel | None = None
-        self.pending_layout: QVBoxLayout | None = None
+        self.work_segment: SegmentedWidget | None = None
+        self.work_stack: QStackedWidget | None = None
+        self.queue_layout: QVBoxLayout | None = None
+        self.finish_layout: QVBoxLayout | None = None
+        self.queue_count_label: QLabel | None = None
+        self.finish_count_label: QLabel | None = None
+        self.pending_layout: QVBoxLayout | None = None  # active list (queue or finish)
         self.pending_count_label: QLabel | None = None
+        self.work_bucket: str = "queue"
         self.detail_title: QLabel | None = None
-        self.detail_source: QLabel | None = None
-        self.detail_stage_chip: QLabel | None = None
-        self.detail_status_chip: QLabel | None = None
-        self.detail_pkl_label: QLabel | None = None
-        self.detail_message: QLabel | None = None
+        self.detail_episode: QLabel | None = None
         self.detail_open_source_btn: PushButton | None = None
         self.detail_open_folder_btn: PushButton | None = None
+        # Kept as None aliases so older refresh paths / tests never AttributeError.
+        self.detail_status_chip: QLabel | None = None
+        self.detail_source: QLabel | None = None
+        self.detail_stage_chip: QLabel | None = None
+        self.detail_pkl_label: QLabel | None = None
+        self.detail_message: QLabel | None = None
         self.debug_drawer: QFrame | None = None
         self.debug_text: TextEdit | None = None
         self.detail_entries: list[dict[str, str]] = []
@@ -139,7 +154,11 @@ class SchedulePanel:
             ("状态", presentation.plan.automation_label),
             ("缓存", f"{presentation.cache.status} ({presentation.cache.book_count})"),
             ("对象", len(presentation.sources)),
-            ("待处理", len(presentation.pending_items)),
+            (
+                "章节",
+                f"待下载 {sum(1 for item in presentation.pending_items if self._item_bucket(item) == 'queue')} / "
+                f"已下载 {sum(1 for item in presentation.pending_items if self._item_bucket(item) == 'finish')}",
+            ),
             ("运行", presentation.run.status),
             ("阶段", presentation.run.stage or "-"),
             ("最近结果", host.ui.redact(host.schedule.last_result)),
@@ -225,13 +244,13 @@ class SchedulePanel:
         self.run_button = PrimaryPushButton(FIF.PLAY, "立刻执行", band)
         self.run_button.clicked.connect(lambda _checked=False: self.host.run_schedule_now())
         subscribe_button = PushButton(FIF.LINK, "打开追更配置", band)
-        subscribe_button.setToolTip("订阅配置由 SpiderGUI 主窗口管理")
+        self._set_fluent_tooltip(subscribe_button, "订阅配置由 SpiderGUI 主窗口管理")
         subscribe_button.clicked.connect(lambda _checked=False: self.open_subscribe_guidance())
         refresh_button = TransparentToolButton(FIF.SYNC, band)
-        refresh_button.setToolTip("刷新订阅运行状态")
+        self._set_fluent_tooltip(refresh_button, "刷新订阅运行状态")
         refresh_button.clicked.connect(lambda _checked=False: self.host.refresh_status(schedule_full=True))
         clear_button = TransparentToolButton(FIF.BROOM, band)
-        clear_button.setToolTip("清空订阅运行历史（确认后执行）")
+        self._set_fluent_tooltip(clear_button, "清空订阅运行历史（确认后执行）")
         clear_button.clicked.connect(lambda _checked=False: self.clear_history())
         self.debug_switch = SwitchButton(band)
         self.debug_switch.setText("Debug")
@@ -298,6 +317,23 @@ class SchedulePanel:
         self.plan_layout.setVerticalSpacing(4)
         plan_layout.addWidget(grid_host)
 
+        # Binding profile = which subscription_*.yml tray executes.
+        binding_row = QHBoxLayout()
+        binding_row.setContentsMargins(0, 4, 0, 0)
+        binding_row.setSpacing(8)
+        binding_label = CaptionLabel("绑定", plan_frame)
+        binding_label.setObjectName("TrayMutedLabel")
+        binding_label.setStyleSheet(muted_label_stylesheet())
+        self.binding_combo = ComboBox(plan_frame)
+        self.binding_combo.setMinimumWidth(140)
+        self.binding_combo.setObjectName("ScheduleBindingCombo")
+        install_tray_combo_menu_hardening(self.binding_combo)
+        self._set_fluent_tooltip(self.binding_combo, "切换要执行的 subscription_*.yml")
+        self.binding_combo.currentIndexChanged.connect(self._on_binding_changed)
+        binding_row.addWidget(binding_label)
+        binding_row.addWidget(self.binding_combo, 1)
+        plan_layout.addLayout(binding_row)
+
         # 后巡查 = tray-global catch-up (not SidePanel, not per-book).
         catchup_row = QHBoxLayout()
         catchup_row.setContentsMargins(0, 4, 0, 0)
@@ -307,6 +343,9 @@ class SchedulePanel:
         catchup_label.setStyleSheet(muted_label_stylesheet())
         self.catchup_combo = ComboBox(plan_frame)
         self.catchup_combo.setMinimumWidth(120)
+        self.catchup_combo.setObjectName("ScheduleCatchupCombo")
+        install_tray_combo_menu_hardening(self.catchup_combo)
+        self._set_fluent_tooltip(self.catchup_combo, "后巡查间隔（托盘全局，非单本）")
         from utils.subscription.schema import CATCHUP_PRESET_ITEMS
         from utils.subscription.store import get_subscription_catchup_preset
 
@@ -411,66 +450,77 @@ class SchedulePanel:
         run_layout.addWidget(self.latest_banner)
         layout.addWidget(run_frame)
 
-        pending_frame, pending_layout = self._panel(panel, "SchedulePendingPanel", alt=True)
-        pending_header = QHBoxLayout()
-        pending_header.setContentsMargins(0, 0, 0, 0)
-        pending_header.addWidget(StrongBodyLabel("待处理条目", pending_frame))
-        pending_header.addStretch(1)
-        self.pending_count_label = CaptionLabel("0 个", pending_frame)
-        self.pending_count_label.setObjectName("TrayMutedLabel")
-        self.pending_count_label.setStyleSheet(muted_label_stylesheet())
-        pending_header.addWidget(self.pending_count_label)
-        pending_layout.addLayout(pending_header)
-        pending_scroll, self.pending_layout = self._scroll_host(pending_frame)
-        pending_layout.addWidget(pending_scroll, 1)
-        layout.addWidget(pending_frame, 1)
+        work_frame, work_layout = self._panel(panel, "SchedulePendingPanel", alt=True)
+        self.work_segment = SegmentedWidget(work_frame)
+        self.work_stack = QStackedWidget(work_frame)
+
+        queue_page = QWidget()
+        queue_box = QVBoxLayout(queue_page)
+        queue_box.setContentsMargins(0, 0, 0, 0)
+        queue_box.setSpacing(4)
+        # Count only — bucket name is already the Segmented label (no "N 个已落地" echo).
+        self.queue_count_label = CaptionLabel("0", queue_page)
+        self.queue_count_label.setObjectName("TrayMutedLabel")
+        self.queue_count_label.setStyleSheet(muted_label_stylesheet())
+        queue_scroll, self.queue_layout = self._scroll_host(queue_page)
+        queue_box.addWidget(self.queue_count_label)
+        queue_box.addWidget(queue_scroll, 1)
+
+        finish_page = QWidget()
+        finish_box = QVBoxLayout(finish_page)
+        finish_box.setContentsMargins(0, 0, 0, 0)
+        finish_box.setSpacing(4)
+        self.finish_count_label = CaptionLabel("0", finish_page)
+        self.finish_count_label.setObjectName("TrayMutedLabel")
+        self.finish_count_label.setStyleSheet(muted_label_stylesheet())
+        finish_scroll, self.finish_layout = self._scroll_host(finish_page)
+        finish_box.addWidget(self.finish_count_label)
+        finish_box.addWidget(finish_scroll, 1)
+
+        self.work_stack.addWidget(queue_page)
+        self.work_stack.addWidget(finish_page)
+        self.work_segment.addItem(
+            "queue",
+            "待下载",
+            onClick=lambda _checked=False: self._select_work_bucket("queue"),
+        )
+        self.work_segment.addItem(
+            "finish",
+            "已下载",
+            onClick=lambda _checked=False: self._select_work_bucket("finish"),
+        )
+        self.work_segment.setCurrentItem("queue")
+        self.pending_layout = self.queue_layout
+        self.pending_count_label = self.queue_count_label
+        work_layout.addWidget(self.work_segment)
+        work_layout.addWidget(self.work_stack, 1)
+        layout.addWidget(work_frame, 1)
         return panel
 
     def _build_detail_panel(self, parent) -> QWidget:
+        """Right rail: identity + actions. Bucket (待下载/已下载) already owns status."""
         frame, layout = self._panel(parent, "ScheduleDetailPanel")
-        layout.addWidget(StrongBodyLabel("条目详情", frame))
+        layout.addWidget(StrongBodyLabel("详情", frame))
         self.detail_title = BodyLabel("-", frame)
         self.detail_title.setWordWrap(True)
         self.detail_title.setStyleSheet(detail_title_stylesheet())
-        self.detail_source = CaptionLabel("-", frame)
-        self.detail_source.setObjectName("TrayMutedLabel")
-        self.detail_source.setWordWrap(True)
-        self.detail_source.setFont(tray_mono_font(8))
-        self.detail_source.setStyleSheet(muted_label_stylesheet())
-        chips = QHBoxLayout()
-        chips.setContentsMargins(0, 0, 0, 0)
-        chips.setSpacing(4)
-        self.detail_stage_chip = QLabel(frame)
-        self.detail_status_chip = QLabel(frame)
-        chips.addWidget(self.detail_stage_chip)
-        chips.addWidget(self.detail_status_chip)
-        chips.addStretch(1)
-        pkl_title = CaptionLabel("PKL BOOKINFO", frame)
-        pkl_title.setObjectName("TrayMutedLabel")
-        pkl_title.setStyleSheet(section_heading_stylesheet())
-        self.detail_pkl_label = CaptionLabel("-", frame)
-        self.detail_pkl_label.setObjectName("TrayPklDetail")
-        self.detail_pkl_label.setWordWrap(True)
-        self.detail_pkl_label.setFont(tray_mono_font(8))
-        self.detail_pkl_label.setStyleSheet(pkl_detail_stylesheet())
+        self.detail_episode = CaptionLabel("", frame)
+        self.detail_episode.setObjectName("TrayMutedLabel")
+        self.detail_episode.setStyleSheet(muted_label_stylesheet())
+        self.detail_episode.setVisible(False)
+        self.detail_status_chip = None
         self.detail_open_source_btn = PushButton(FIF.LINK, "打开来源", frame)
         self.detail_open_source_btn.setEnabled(False)
         self.detail_open_source_btn.clicked.connect(lambda _checked=False: self.open_detail_source())
         self.detail_open_folder_btn = PushButton(FIF.FOLDER, "打开本地目录", frame)
         self.detail_open_folder_btn.setEnabled(False)
-        self.detail_open_folder_btn.setToolTip("下载完成后可打开目录")
-        self.detail_message = CaptionLabel("选择一个待处理条目查看 BookInfo 派生字段。", frame)
-        self.detail_message.setObjectName("TrayMutedLabel")
-        self.detail_message.setWordWrap(True)
-        self.detail_message.setStyleSheet(muted_label_stylesheet())
+        self.detail_open_folder_btn.clicked.connect(lambda _checked=False: self.open_detail_folder())
+        self._set_fluent_tooltip(self.detail_open_source_btn, "在浏览器打开来源页")
+        self._set_fluent_tooltip(self.detail_open_folder_btn, "打开本地章节目录")
         layout.addWidget(self.detail_title)
-        layout.addWidget(self.detail_source)
-        layout.addLayout(chips)
-        layout.addWidget(pkl_title)
-        layout.addWidget(self.detail_pkl_label)
+        layout.addWidget(self.detail_episode)
         layout.addWidget(self.detail_open_source_btn)
         layout.addWidget(self.detail_open_folder_btn)
-        layout.addWidget(self.detail_message)
         layout.addStretch(1)
         return frame
 
@@ -481,7 +531,7 @@ class SchedulePanel:
         header.addWidget(StrongBodyLabel("原始 Schedule Payload", drawer))
         header.addStretch(1)
         copy_button = TransparentToolButton(FIF.COPY, drawer)
-        copy_button.setToolTip("复制已脱敏 Schedule debug 内容")
+        self._set_fluent_tooltip(copy_button, "复制已脱敏 Schedule debug 内容")
         copy_button.clicked.connect(
             lambda _checked=False: self.host.ui.copy_to_clipboard(self.debug_text.toPlainText() if self.debug_text is not None else "")
         )
@@ -510,7 +560,7 @@ class SchedulePanel:
         host.ui.set_label(self.run_trigger_label, f"触发: {trigger or '-'}")
         host.ui.set_label(self.run_elapsed_label, host.ui.duration_label(float(elapsed_sec) * 1000))
         host.ui.set_label(self.run_scanned_label, f"扫描 {scanned}")
-        host.ui.set_label(self.run_pending_label, f"待处理 {pending}")
+        host.ui.set_label(self.run_pending_label, f"章节 {pending}")
         host.ui.set_label(self.run_jobs_label, f"任务 {jobs}")
         host.ui.set_label(self.run_meta_label, "元数据 ✓" if meta else "元数据 -")
         if self.stage_rail is not None:
@@ -522,7 +572,7 @@ class SchedulePanel:
         host.ui.set_label(self.latest_banner, latest or "-")
 
     def _on_catchup_changed(self, *_args) -> None:
-        if not hasattr(self, "catchup_combo") or self.catchup_combo is None:
+        if self.catchup_combo is None:
             return
         preset = self.catchup_combo.currentData()
         if preset is None:
@@ -533,7 +583,60 @@ class SchedulePanel:
         set_subscription_catchup_preset(str(preset))
         self.host.refresh_status(schedule_full=True)
 
+    def _on_binding_changed(self, *_args) -> None:
+        if self._binding_combo_guard or self.binding_combo is None:
+            return
+        name = self.binding_combo.currentData()
+        if name is None:
+            return
+        from utils.subscription import (
+            get_active_subscription_customname,
+            set_active_subscription_customname,
+        )
+
+        wanted = str(name).strip()
+        if not wanted or wanted == get_active_subscription_customname():
+            return
+        set_active_subscription_customname(wanted)
+        self.host.schedule.rebind_active_store()
+        self.host.refresh_status(schedule_full=True)
+
+    def _sync_binding_combo(self, presentation: SchedulePresentation) -> None:
+        if self.binding_combo is None:
+            return
+        from utils.subscription import (
+            get_active_subscription_customname,
+            list_subscription_customnames,
+        )
+
+        names = list(list_subscription_customnames(include_default=True))
+        active = get_active_subscription_customname()
+        # Prefer active name even if list is momentarily empty (cold dir).
+        if active and active not in names:
+            names.insert(0, active)
+        current_data = [
+            str(self.binding_combo.itemData(index) or "")
+            for index in range(self.binding_combo.count())
+        ]
+        self._binding_combo_guard = True
+        try:
+            if current_data != names:
+                self.binding_combo.clear()
+                for name in names:
+                    # Display short profile id; full yml name is obvious from convention.
+                    self.binding_combo.addItem(name, userData=name)
+            target_index = 0
+            for index in range(self.binding_combo.count()):
+                if str(self.binding_combo.itemData(index) or "") == active:
+                    target_index = index
+                    break
+            if self.binding_combo.currentIndex() != target_index:
+                self.binding_combo.setCurrentIndex(target_index)
+        finally:
+            self._binding_combo_guard = False
+
     def _render_plan(self, presentation: SchedulePresentation) -> None:
+        self._sync_binding_combo(presentation)
         if self.plan_layout is None:
             return
         clear_layout(self.plan_layout)
@@ -600,9 +703,27 @@ class SchedulePanel:
         self.sources_layout.addStretch(1)
 
     def _sources_empty_text(self, presentation: SchedulePresentation) -> str:
-        return "还没有追更对象。请从预览页勾选作品加入追更，或在主窗口订阅配置里添加 follow bid。"
+        profile = ""
+        owner = str(presentation.plan.config_owner or "")
+        if "«" in owner and "»" in owner:
+            profile = owner.split("«", 1)[1].split("»", 1)[0]
+        if profile:
+            return (
+                f"绑定 «{profile}» 的 subscription_*.yml 没有启用书目。"
+                "请在追更工作台选中卡片，用 SidePanel 启用并保存周期（写入 yml）；"
+                "tray 只执行 yml，不会扫描整库收藏。"
+            )
+        return (
+            "当前 binding 的 yml 没有启用书。"
+            "请打开追更工作台 SidePanel 配置并保存到 subscription_*.yml。"
+        )
 
     def _source_card(self, source) -> QWidget:
+        # Left column is narrow (~1/4 dialog). Elide budgets stay tight and fixed.
+        _SOURCE_TITLE_ELIDE = 112
+        _SOURCE_LOCATOR_ELIDE = 96
+        _SOURCE_SLOT_ELIDE = 72
+
         card = QFrame()
         card.setObjectName("ScheduleSourceCard")
         card.setStyleSheet(source_card_stylesheet())
@@ -613,8 +734,14 @@ class SchedulePanel:
         top.setContentsMargins(0, 0, 0, 0)
         top.setSpacing(6)
         top.addWidget(self._site_badge(source.site, card))
-        title = BodyLabel(source.title or source.locator or "-", card)
+        title = BodyLabel("-", card)
         title.setStyleSheet(body_text_stylesheet())
+        title.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Preferred)
+        self._set_elided_label(
+            title,
+            source.title or source.locator or "-",
+            max_width=_SOURCE_TITLE_ELIDE,
+        )
         top.addWidget(title, 1)
         enabled = CaptionLabel(self._source_status_label(source.status), card)
         enabled.setStyleSheet(accent_ok_label_stylesheet() if source.enabled else muted_label_stylesheet())
@@ -623,20 +750,31 @@ class SchedulePanel:
         bottom = QHBoxLayout()
         bottom.setContentsMargins(0, 0, 0, 0)
         bottom.setSpacing(6)
-        locator = CaptionLabel(source.locator or "-", card)
+        locator = CaptionLabel("-", card)
         locator.setObjectName("TrayMutedLabel")
         locator.setStyleSheet(muted_label_stylesheet())
         locator.setFont(tray_mono_font(8))
+        locator.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Preferred)
+        self._set_elided_label(
+            locator,
+            source.locator or "-",
+            max_width=_SOURCE_LOCATOR_ELIDE,
+        )
         bottom.addWidget(locator, 1)
-        if source.pending_count:
-            pending = CaptionLabel(f"{source.pending_count} 个待处理", card)
-            pending.setObjectName("TrayAccentInfoLabel")
-            pending.setStyleSheet(accent_info_label_stylesheet())
-        else:
-            pending = CaptionLabel(source.latest or "最近记录", card)
-            pending.setObjectName("TrayMutedLabel")
-            pending.setStyleSheet(muted_label_stylesheet())
-        bottom.addWidget(pending)
+        # Right meta is the CheckSlot fingerprint (刊期), never a pending-count rewrite.
+        slot_text = str(source.latest or "").strip() or "—"
+        slot_label = CaptionLabel(slot_text, card)
+        slot_label.setObjectName("TrayMutedLabel")
+        slot_label.setFont(tray_mono_font(8))
+        slot_label.setStyleSheet(muted_label_stylesheet())
+        slot_label.setAlignment(Qt.AlignmentFlag.AlignRight | Qt.AlignmentFlag.AlignVCenter)
+        self._set_fluent_tooltip(slot_label, slot_text)
+        # Fixed-ish budget so long fingerprints elide without eating the title column.
+        metrics = QFontMetrics(slot_label.font())
+        slot_label.setText(
+            metrics.elidedText(slot_text, Qt.TextElideMode.ElideRight, _SOURCE_SLOT_ELIDE)
+        )
+        bottom.addWidget(slot_label)
         box.addLayout(bottom)
         return card
 
@@ -649,50 +787,119 @@ class SchedulePanel:
         }
         return labels.get(str(status or ""), str(status or "-"))
 
+    def _select_work_bucket(self, bucket: str) -> None:
+        name = "finish" if str(bucket or "") == "finish" else "queue"
+        self.work_bucket = name
+        if self.work_stack is not None:
+            self.work_stack.setCurrentIndex(1 if name == "finish" else 0)
+        if self.work_segment is not None:
+            self.work_segment.setCurrentItem(name)
+        self.pending_layout = self.finish_layout if name == "finish" else self.queue_layout
+        self.pending_count_label = (
+            self.finish_count_label if name == "finish" else self.queue_count_label
+        )
+        if self.latest_presentation is not None:
+            self._render_pending(self.latest_presentation)
+
     def _render_pending(self, presentation: SchedulePresentation) -> None:
-        if self.pending_layout is None:
+        if self.queue_layout is None or self.finish_layout is None:
             return
-        clear_layout(self.pending_layout)
-        items = presentation.pending_items
-        self.detail_entries = [self._detail_entry(item) for item in items]
-        self.host.ui.set_label(self.pending_count_label, f"{len(items)} 个")
-        if not items:
+        all_items = list(presentation.pending_items or [])
+        queue_items = [item for item in all_items if self._item_bucket(item) == "queue"]
+        finish_items = [item for item in all_items if self._item_bucket(item) == "finish"]
+        self.host.ui.set_label(self.queue_count_label, str(len(queue_items)))
+        self.host.ui.set_label(self.finish_count_label, str(len(finish_items)))
+
+        active_items = finish_items if self.work_bucket == "finish" else queue_items
+        self.detail_entries = [self._detail_entry(item) for item in active_items]
+        self.pending_layout = self.finish_layout if self.work_bucket == "finish" else self.queue_layout
+        self.pending_count_label = (
+            self.finish_count_label if self.work_bucket == "finish" else self.queue_count_label
+        )
+
+        for layout in (self.queue_layout, self.finish_layout):
+            clear_layout(layout)
+
+        self._fill_work_list(
+            self.queue_layout,
+            queue_items,
+            empty_text="空",
+            bucket="queue",
+        )
+        self._fill_work_list(
+            self.finish_layout,
+            finish_items,
+            empty_text="空",
+            bucket="finish",
+        )
+
+        if not active_items:
             self.selected_index = -1
-            empty = CaptionLabel("暂无待处理条目。可以手动执行一次检查，或等待下一次自动检查。")
-            empty.setObjectName("TrayMutedLabel")
-            empty.setStyleSheet(muted_label_stylesheet())
-            empty.setWordWrap(True)
-            self.pending_layout.addWidget(empty)
-            self.pending_layout.addStretch(1)
             self._render_detail(None)
             return
-        for index, item in enumerate(items):
-            self.pending_layout.addWidget(self._pending_card(item, index))
-        self.pending_layout.addStretch(1)
-        if not 0 <= self.selected_index < len(items):
+        if not 0 <= self.selected_index < len(active_items):
             self.selected_index = 0
         self._render_detail(self.detail_entries[self.selected_index])
 
+    def _item_bucket(self, item) -> str:
+        status = str(getattr(item, "status", "") or "").strip().casefold()
+        local_path = str(getattr(item, "local_path", "") or "").strip()
+        if status in {"finished", "done", "complete", "completed", "ok", "submitted"} or local_path:
+            return "finish"
+        return "queue"
+
+    def _fill_work_list(self, layout, items, *, empty_text: str, bucket: str) -> None:
+        if layout is None:
+            return
+        if not items:
+            empty = CaptionLabel(empty_text)
+            empty.setObjectName("TrayMutedLabel")
+            empty.setStyleSheet(muted_label_stylesheet())
+            empty.setWordWrap(True)
+            layout.addWidget(empty)
+            layout.addStretch(1)
+            return
+        for index, item in enumerate(items):
+            # Cards only selectable when their bucket is active.
+            card_index = index if bucket == self.work_bucket else -1
+            layout.addWidget(self._pending_card(item, card_index))
+        layout.addStretch(1)
+
     def _detail_entry(self, item) -> dict[str, str]:
+        local_path = str(getattr(item, "local_path", "") or "").strip()
+        cover = str(
+            getattr(item, "local_cover_path", "")
+            or getattr(item, "cover_url", "")
+            or ""
+        ).strip()
+        status = str(item.status or "queued")
+        if local_path:
+            status = "finished"
         return {
             "title": item.title or "-",
             "episode": item.episode or "-",
             "site": item.site or "-",
-            "status": item.status or "pending",
+            "status": status,
             "stage": item.stage or "-",
             "message": item.message or "-",
             "source_id": item.source_id or "-",
             "source_url": item.source_url or "",
-            "cover_url": item.cover_url or "",
+            "cover_url": cover,
+            "local_path": local_path,
         }
 
     def _pending_card(self, item, index: int) -> QWidget:
-        selected = index == self.selected_index
+        # Center column is wider than left objects list — use a looser elide budget.
+        _WORK_TITLE_ELIDE = 220
+        _WORK_EPISODE_ELIDE = 180
+
+        selected = index >= 0 and index == self.selected_index
         card = ClickableFrame()
         card.setObjectName("SchedulePendingCard")
         card.setStyleSheet(pending_card_stylesheet(selected=selected))
         card.setCursor(Qt.CursorShape.PointingHandCursor)
-        card._on_click = lambda i=index: self.select_pending(i)
+        if index >= 0:
+            card._on_click = lambda i=index: self.select_pending(i)
         row = QHBoxLayout(card)
         row.setContentsMargins(6, 6, 6, 6)
         row.setSpacing(8)
@@ -701,8 +908,11 @@ class SchedulePanel:
         cover.setFixedSize(36, 50)
         cover.setAlignment(Qt.AlignmentFlag.AlignCenter)
         cover.setStyleSheet(cover_placeholder_stylesheet(small=True))
-        if item.cover_url:
-            self.host.server_panel.apply_cover(cover, item.cover_url)
+        cover_ref = str(
+            getattr(item, "local_cover_path", "") or getattr(item, "cover_url", "") or ""
+        ).strip()
+        if cover_ref:
+            self.host.server_panel.apply_cover(cover, cover_ref)
         row.addWidget(cover)
         body = QVBoxLayout()
         body.setContentsMargins(0, 0, 0, 0)
@@ -713,35 +923,27 @@ class SchedulePanel:
         title_box = QVBoxLayout()
         title_box.setContentsMargins(0, 0, 0, 0)
         title_box.setSpacing(0)
-        title = BodyLabel(item.title or "-", card)
+        book_title = str(item.title or "").strip()
+        episode_name = str(item.episode or "").strip()
+        primary_text = book_title or episode_name or "-"
+        secondary_text = (
+            episode_name if book_title and episode_name and episode_name != book_title else ""
+        )
+        title = BodyLabel("-", card)
         title.setStyleSheet(body_text_stylesheet())
-        episode = CaptionLabel(item.episode or "-", card)
-        episode.setObjectName("TrayAccentInfoLabel")
-        episode.setStyleSheet(accent_info_label_stylesheet())
+        title.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Preferred)
+        self._set_elided_label(title, primary_text, max_width=_WORK_TITLE_ELIDE)
         title_box.addWidget(title)
-        title_box.addWidget(episode)
+        if secondary_text:
+            episode = CaptionLabel("-", card)
+            episode.setObjectName("TrayAccentInfoLabel")
+            episode.setStyleSheet(accent_info_label_stylesheet())
+            episode.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Preferred)
+            self._set_elided_label(episode, secondary_text, max_width=_WORK_EPISODE_ELIDE)
+            title_box.addWidget(episode)
         head.addLayout(title_box, 1)
         head.addWidget(self._site_badge(item.site, card))
         body.addLayout(head)
-        bottom = QHBoxLayout()
-        bottom.setContentsMargins(0, 0, 0, 0)
-        bottom.setSpacing(6)
-        message = CaptionLabel(item.message or item.stage or "-", card)
-        message.setObjectName("TrayMutedLabel")
-        message.setStyleSheet(muted_label_stylesheet())
-        bottom.addWidget(message, 1)
-        open_button = TransparentToolButton(FIF.LINK, card)
-        open_button.setFixedSize(22, 22)
-        open_button.setToolTip("打开来源")
-        open_button.setEnabled(bool(item.source_url))
-        open_button.clicked.connect(lambda _checked=False, url=item.source_url: self.host.server_panel.open_url(url))
-        details_button = TransparentToolButton(FIF.VIEW, card)
-        details_button.setFixedSize(22, 22)
-        details_button.setToolTip("查看详情")
-        details_button.clicked.connect(lambda _checked=False, i=index: self.select_pending(i))
-        bottom.addWidget(open_button)
-        bottom.addWidget(details_button)
-        body.addLayout(bottom)
         row.addLayout(body, 1)
         return card
 
@@ -753,53 +955,85 @@ class SchedulePanel:
         self._render_detail(self.detail_entries[index])
 
     def _restyle_pending_cards(self, selected_index: int) -> None:
-        if self.pending_layout is None:
+        layout = self.pending_layout
+        if layout is None:
             return
         card_index = 0
-        for i in range(self.pending_layout.count()):
-            item = self.pending_layout.itemAt(i)
+        for i in range(layout.count()):
+            item = layout.itemAt(i)
             widget = item.widget() if item is not None else None
             if widget is None or widget.objectName() != "SchedulePendingCard":
                 continue
             widget.setStyleSheet(pending_card_stylesheet(selected=card_index == selected_index))
             card_index += 1
 
+    def _set_fluent_tooltip(self, widget, text: str) -> None:
+        """Theme-aware Fluent tooltip; bubble is not parented under ManageDialog."""
+        install_tray_fluent_tooltip(widget, text)
+
+    def _set_elided_label(self, label: QLabel, full_text: str, *, max_width: int | None = None) -> None:
+        """Elide with an explicit pixel budget.
+
+        Callers must pass different ``max_width`` for left objects vs center work
+        lists — the two columns are not the same width.
+        """
+        text = str(full_text or "").strip() or "-"
+        self._set_fluent_tooltip(label, text)
+        width = int(max_width or 0)
+        if width <= 0:
+            raise ValueError("_set_elided_label requires max_width (column-specific budget)")
+        metrics = QFontMetrics(label.font())
+        label.setText(metrics.elidedText(text, Qt.TextElideMode.ElideRight, width))
+
     def _render_detail(self, entry) -> None:
+        """Identity + actions only. Status is the Segmented bucket, not a badge."""
         host = self.host
         if self.detail_title is None:
             return
         if not entry:
-            host.ui.set_label(self.detail_title, "-")
-            host.ui.set_label(self.detail_source, "-")
-            self.detail_stage_chip.setText("")
-            self.detail_stage_chip.setStyleSheet("")
-            self.detail_status_chip.setText("")
-            self.detail_status_chip.setStyleSheet("")
-            host.ui.set_label(self.detail_pkl_label, "-")
-            self.detail_open_source_btn.setEnabled(False)
-            host.ui.set_label(self.detail_message, "选择一个待处理条目查看 BookInfo 派生字段。")
+            host.ui.set_label(self.detail_title, "未选择")
+            if self.detail_episode is not None:
+                self.detail_episode.setVisible(False)
+                host.ui.set_label(self.detail_episode, "")
+            if self.detail_open_source_btn is not None:
+                self.detail_open_source_btn.setEnabled(False)
+                self._set_fluent_tooltip(self.detail_open_source_btn, "")
+            if self.detail_open_folder_btn is not None:
+                self.detail_open_folder_btn.setEnabled(False)
+                self._set_fluent_tooltip(self.detail_open_folder_btn, "")
             return
-        host.ui.set_label(self.detail_title, entry.get("title") or "-")
-        host.ui.set_label(self.detail_source, entry.get("source_id") or "-")
-        host.ui.set_chip(self.detail_stage_chip, entry.get("stage") or "-")
-        host.ui.set_chip(self.detail_status_chip, entry.get("status") or "pending")
-        host.ui.set_label(
-            self.detail_pkl_label,
-            "\n".join(
-                [
-                    f"episode: {entry.get('episode') or '-'}",
-                    f"site: {entry.get('site') or '-'}",
-                    f"cover_ref: {entry.get('cover_url') or '-'}",
-                    f"source: {entry.get('source_url') or '-'}",
-                ]
-            ),
-        )
-        self.detail_open_source_btn.setEnabled(bool(entry.get("source_url")))
-        host.ui.set_label(self.detail_message, entry.get("message") or "-")
+
+        book_title = str(entry.get("title") or "").strip() or "-"
+        episode_text = str(entry.get("episode") or "").strip()
+        host.ui.set_label(self.detail_title, book_title)
+        if self.detail_episode is not None:
+            if episode_text and episode_text != book_title:
+                host.ui.set_label(self.detail_episode, episode_text)
+                self.detail_episode.setVisible(True)
+            else:
+                host.ui.set_label(self.detail_episode, "")
+                self.detail_episode.setVisible(False)
+
+        local_path = str(entry.get("local_path") or "").strip()
+        source_url = str(entry.get("source_url") or "").strip()
+
+        if self.detail_open_source_btn is not None:
+            self.detail_open_source_btn.setEnabled(bool(source_url))
+            self._set_fluent_tooltip(self.detail_open_source_btn, source_url)
+        if self.detail_open_folder_btn is not None:
+            self.detail_open_folder_btn.setEnabled(bool(local_path))
+            self._set_fluent_tooltip(self.detail_open_folder_btn, local_path)
 
     def open_detail_source(self) -> None:
         if 0 <= self.selected_index < len(self.detail_entries):
             self.host.server_panel.open_url(self.detail_entries[self.selected_index].get("source_url") or "")
+
+    def open_detail_folder(self) -> None:
+        if not 0 <= self.selected_index < len(self.detail_entries):
+            return
+        local_path = str(self.detail_entries[self.selected_index].get("local_path") or "").strip()
+        if local_path:
+            self.host.server_panel.open_path(local_path)
 
     def open_subscribe_guidance(self) -> None:
         box = MessageBox(

--- a/server/tray/server_panel.py
+++ b/server/tray/server_panel.py
@@ -27,6 +27,7 @@ from server.tray.style import cover_placeholder_stylesheet, error_label_styleshe
 from server.tray.ui_common import (
     CompactKeyValueTable,
     configure_tray_qt_fonts,
+    install_tray_fluent_tooltip,
     tray_mono_font,
 )
 from utils import conf, temp_p
@@ -93,7 +94,7 @@ class ServerTaskRow(QFrame):
         percent = host.ui.coerce_percent(item.get("percent"))
         title_text = str(item.get("task_title") or item.get("task_id") or "-")
         self._title.setText(title_text)
-        self._title.setToolTip(title_text)
+        install_tray_fluent_tooltip(self._title, title_text)
         self._page_label.setText(f"{downloaded}/{total}P" if total else f"{downloaded}P")
         self._percent_label.setText(f"{percent}%")
         host.ui.set_chip(self._status_chip, str(item.get("status") or "running"))
@@ -105,17 +106,17 @@ class ServerTaskRow(QFrame):
         latest = str(item.get("error") or item.get("latest_message") or item.get("url") or "-")
         meta_text = f"stage: {stage}    latest: {host.ui.strip_html(latest)}"
         self._meta.setText(meta_text)
-        self._meta.setToolTip(meta_text)
+        install_tray_fluent_tooltip(self._meta, meta_text)
         self._local_path = str(item.get("local_path") or "")
         self._source_url = str(item.get("source_url") or item.get("url") or "")
-        self._folder.setToolTip(self._local_path or "no local path")
+        install_tray_fluent_tooltip(self._folder, self._local_path or "no local path")
         self._folder.setEnabled(bool(self._local_path))
-        self._link.setToolTip(self._source_url or "no source url")
+        install_tray_fluent_tooltip(self._link, self._source_url or "no source url")
         self._link.setEnabled(bool(self._source_url))
         cover_path = self._panel.task_cover_path(item)
         if cover_path and cover_path != self._cover_path:
             self._cover_path = cover_path
-            self._cover.setToolTip(cover_path)
+            install_tray_fluent_tooltip(self._cover, cover_path)
             self._panel.apply_cover(self._cover, cover_path)
 
 
@@ -346,9 +347,10 @@ class ServerPanel:
         clear_button.setObjectName("ServerRuntimeClearButton")
         clear_button.clicked.connect(lambda _checked=False: self.clear_runtime_history())
         restart_server = TransparentToolButton(CgsIcon.REBOOT, band)
-        restart_server.setToolTip("重启")
+        install_tray_fluent_tooltip(restart_server, "重启")
         restart_server.clicked.connect(lambda _checked=False: self.host.restart_server_surface())
         quit_server = TransparentToolButton(FIF.POWER_BUTTON, band)
+        install_tray_fluent_tooltip(quit_server, "退出 CGS Server")
         quit_server.clicked.connect(lambda _checked=False: self.host.shutdown())
         layout.addWidget(debug_label)
         layout.addWidget(self.debug_switch)

--- a/server/tray/style.py
+++ b/server/tray/style.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from PySide6.QtWidgets import QMenu
+
 from utils import ori_path
 from GUI.core.theme import CustTheme, theme_mgr
 from GUI.core.theme.qss_template import read_templated_qss_tokens, render_templated_qss_section
@@ -45,6 +47,228 @@ def build_dialog_stylesheet() -> str:
             _render_section("mcp"),
         )
     )
+
+
+def tray_context_menu_stylesheet() -> str:
+    """Opaque native QMenu chrome for the system-tray icon menu."""
+    return _render_section("tray_context_menu")
+
+
+def apply_tray_context_menu_theme(menu: QMenu | None) -> None:
+    """Apply the active tray-menu theme to a menu and all of its submenus."""
+    if menu is None:
+        return
+    stylesheet = tray_context_menu_stylesheet()
+    for context_menu in (menu, *menu.findChildren(QMenu)):
+        context_menu.setStyleSheet(stylesheet)
+
+
+def apply_manage_dialog_theme(dialog) -> None:
+    """Paint ManageDialog panels without cascading into Fluent popups.
+
+    ``QWidget.setStyleSheet`` on the dialog still matches descendants — including
+    ComboBoxMenu / ToolTip if they stay parented under the dialog. Keep every
+    rule objectName-scoped (tray.qss contract) and re-apply Fluent sheets on
+    known popup classes after the dialog sheet is set.
+    """
+    if dialog is None:
+        return
+    dialog.setStyleSheet(build_dialog_stylesheet())
+    _reassert_fluent_popup_styles(dialog)
+
+
+def _reassert_fluent_popup_styles(root) -> None:
+    """Force Fluent MENU/TOOL_TIP sheets onto live popups under ``root``."""
+    from qfluentwidgets import RoundMenu, ToolTip
+    from qfluentwidgets.common.style_sheet import FluentStyleSheet
+
+    for menu in root.findChildren(RoundMenu):
+        FluentStyleSheet.MENU.apply(menu)
+        # Collapse the translucent outer shell that reads as a ghost mask ring.
+        _collapse_round_menu_ghost_shell(menu)
+    for tip in root.findChildren(ToolTip):
+        FluentStyleSheet.TOOL_TIP.apply(tip)
+        harden_tray_tooltip(tip)
+
+
+def _tray_popup_fill_color() -> str:
+    """Opaque fill matching Fluent MenuActionListWidget for the active theme."""
+    return "#2b2b2b" if current_theme_name() == "dark" else "#f9f9f9"
+
+
+def _collapse_round_menu_ghost_shell(menu) -> None:
+    """Kill Windows ghost ring around RoundMenu **before first show**.
+
+    Root cause (proven with QScreen.grabWindow vs widget.grab on real
+    ServerManageDialog + ComboBox):
+    1. Fluent ``menu.qss``: ``RoundMenu { background: transparent }`` + layout
+       margins 12/8/12/20 for drop-shadow.
+    2. ``ComboBoxMenu`` adds ``view.setViewportMargins(0, 2, 0, 6)``.
+    3. Widget grab corners alpha=0; Windows DWM fills those holes + translucent
+       pad with an opaque gray rectangle → user "ghost mask / FlyoutViewBase".
+    4. Main GUI is not immune; trayDialog on dark desktop makes it obvious.
+
+    Fix (before show / before native window create):
+    - WA_TranslucentBackground OFF
+    - zero hBoxLayout + viewport margins, kill graphics shadow
+    - **replace** stylesheet (do not append onto Fluent transparent rules)
+    - square opaque fill matching list (no radius corner holes)
+    """
+    from PySide6.QtCore import Qt
+    from PySide6.QtGui import QColor, QPalette
+
+    if menu.isVisible():
+        menu.hide()
+
+    fill = _tray_popup_fill_color()
+    text = "#f1f5f9" if current_theme_name() == "dark" else "#0f172a"
+    hover = "rgba(255,255,255,0.06)" if current_theme_name() == "dark" else "rgba(0,0,0,0.06)"
+    border = "rgba(255,255,255,0.10)" if current_theme_name() == "dark" else "rgba(0,0,0,0.10)"
+
+    menu.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground, False)
+    menu.setAttribute(Qt.WidgetAttribute.WA_NoSystemBackground, False)
+    menu.setAttribute(Qt.WidgetAttribute.WA_StyledBackground, True)
+    menu.setWindowFlag(Qt.WindowType.NoDropShadowWindowHint, True)
+
+    layout = getattr(menu, "hBoxLayout", None)
+    if layout is not None:
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(0)
+
+    set_shadow = getattr(menu, "setShadowEffect", None)
+    if callable(set_shadow):
+        set_shadow(blurRadius=0, offset=(0, 0), color=QColor(0, 0, 0, 0))
+
+    view = getattr(menu, "view", None)
+    if view is not None:
+        view.setGraphicsEffect(None)
+        view.setViewportMargins(0, 0, 0, 0)
+        view.setAutoFillBackground(True)
+        view_palette = view.palette()
+        view_palette.setColor(QPalette.ColorRole.Base, QColor(fill))
+        view_palette.setColor(QPalette.ColorRole.Window, QColor(fill))
+        view_palette.setColor(QPalette.ColorRole.Text, QColor(text))
+        view.setPalette(view_palette)
+
+    # Full replace — never leave Fluent "background: transparent" in the cascade.
+    menu.setStyleSheet(
+        f"""
+        RoundMenu {{
+            background-color: {fill};
+            border: none;
+            border-radius: 0px;
+            padding: 0px;
+            margin: 0px;
+        }}
+        MenuActionListWidget {{
+            background-color: {fill};
+            border: 1px solid {border};
+            border-radius: 0px;
+            outline: none;
+            padding: 2px 0px;
+            font: 13px 'Segoe UI', 'Microsoft YaHei UI';
+            color: {text};
+        }}
+        MenuActionListWidget::item {{
+            background-color: transparent;
+            color: {text};
+            border: none;
+            border-radius: 4px;
+            margin: 0px 4px;
+            padding: 6px 12px;
+        }}
+        MenuActionListWidget::item:hover,
+        MenuActionListWidget::item:selected {{
+            background-color: {hover};
+            color: {text};
+        }}
+        MenuActionListWidget::item:disabled {{
+            color: rgba(148, 163, 184, 0.7);
+        }}
+        """
+    )
+    menu.setAutoFillBackground(True)
+    palette = menu.palette()
+    palette.setColor(QPalette.ColorRole.Window, QColor(fill))
+    palette.setColor(QPalette.ColorRole.Base, QColor(fill))
+    palette.setColor(QPalette.ColorRole.Text, QColor(text))
+    menu.setPalette(palette)
+    menu.adjustSize()
+
+
+def harden_tray_tooltip(tip) -> None:
+    """Make a Fluent tooltip opaque before its native popup is shown."""
+    from PySide6.QtCore import Qt
+    from PySide6.QtGui import QColor, QPalette
+
+    fill = _tray_popup_fill_color()
+    text = "#f1f5f9" if current_theme_name() == "dark" else "#0f172a"
+    border = "rgba(255,255,255,0.10)" if current_theme_name() == "dark" else "rgba(0,0,0,0.10)"
+    tip.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground, False)
+    tip.setAttribute(Qt.WidgetAttribute.WA_NoSystemBackground, False)
+    tip.setAttribute(Qt.WidgetAttribute.WA_StyledBackground, True)
+    layout = tip.layout()
+    if layout is not None:
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(0)
+    container = getattr(tip, "container", None)
+    if container is not None:
+        container.setGraphicsEffect(None)
+    tip.setStyleSheet(
+        f"""
+        ToolTip {{
+            background-color: {fill};
+            border: none;
+            border-radius: 0px;
+            padding: 0px;
+            margin: 0px;
+        }}
+        ToolTip > #container {{
+            background-color: {fill};
+            border: 1px solid {border};
+            border-radius: 0px;
+            padding: 6px 10px;
+        }}
+        ToolTip QLabel, ToolTip #contentLabel {{
+            background: transparent;
+            border: none;
+            color: {text};
+            font: 12px 'Segoe UI', 'Microsoft YaHei UI';
+        }}
+        """
+    )
+    tip.setAutoFillBackground(True)
+    palette = tip.palette()
+    palette.setColor(QPalette.ColorRole.Window, QColor(fill))
+    tip.setPalette(palette)
+    tip.adjustSize()
+
+
+def install_tray_combo_menu_hardening(combo) -> None:
+    """Wrap ComboBox menu create so shell collapse runs before first show/exec."""
+    if combo is None or getattr(combo, "_cgs_tray_menu_hardened", False):
+        return
+
+    original_create = combo._createComboMenu
+
+    def _create_hardened_menu():
+        menu = original_create()
+        _collapse_round_menu_ghost_shell(menu)
+        # Also wrap exec: ComboBoxMenu.exec → adjustSize → super.exec(show).
+        # Re-apply collapse immediately before the native window is shown.
+        original_exec = menu.exec
+
+        def _exec_hardened(pos, ani=True, aniType=None):
+            _collapse_round_menu_ghost_shell(menu)
+            if aniType is None:
+                return original_exec(pos, ani)
+            return original_exec(pos, ani, aniType)
+
+        menu.exec = _exec_hardened  # type: ignore[method-assign]
+        return menu
+
+    combo._createComboMenu = _create_hardened_menu  # type: ignore[method-assign]
+    combo._cgs_tray_menu_hardened = True
 
 
 def chip_stylesheet(status: str) -> str:

--- a/server/tray/ui_common.py
+++ b/server/tray/ui_common.py
@@ -20,10 +20,11 @@ from PySide6.QtWidgets import (
     QVBoxLayout,
     QWidget,
 )
-from qfluentwidgets import CaptionLabel, TableWidget
+from qfluentwidgets import CaptionLabel, TableWidget, ToolTip, ToolTipFilter, ToolTipPosition
 
 from server.tray.style import (
     chip_stylesheet,
+    harden_tray_tooltip,
     stage_dot_stylesheet,
     stage_rail_line_stylesheet,
     stage_text_stylesheet,
@@ -284,6 +285,49 @@ class ServerManageDialog(QDialog):
     def closeEvent(self, event) -> None:
         event.ignore()
         self.hide()
+
+
+class TrayFluentToolTipFilter(ToolTipFilter):
+    """ToolTipFilter that does **not** parent the bubble under ManageDialog.
+
+    qfluent default: ``ToolTip(..., parent=widget.window())``. That puts the
+    tooltip in the dialog widget tree, so dialog ``setStyleSheet`` descendants
+    (even accidental ones) paint ghost borders / wrong day-night colors on
+    ToolTip QLabel/QFrame. Parent ``None`` keeps FluentStyleSheet.TOOL_TIP only.
+    """
+
+    def _createToolTip(self):
+        parent_widget = self.parent()
+        text = parent_widget.toolTip() if parent_widget is not None else ""
+        # parent=None: avoid ManageDialog stylesheet tree. Collapse shadow shell
+        # before first show — same Windows translucent-margin ghost as RoundMenu.
+        tip = ToolTip(text, None)
+        harden_tray_tooltip(tip)
+        return tip
+
+
+def install_tray_fluent_tooltip(
+    widget: QWidget | None,
+    text: str = "",
+    *,
+    show_delay_ms: int = 300,
+    position: ToolTipPosition = ToolTipPosition.TOP,
+) -> None:
+    """Theme-aware tooltip for tray surfaces (Manage dialog + cards)."""
+    if widget is None:
+        return
+    tip = str(text or "").strip()
+    widget.setToolTip(tip)
+    for event_filter in list(getattr(widget, "_cgs_fluent_tooltip_filters", []) or []):
+        widget.removeEventFilter(event_filter)
+    widget._cgs_fluent_tooltip_filters = []
+    if not tip:
+        return
+    tooltip_filter = TrayFluentToolTipFilter(
+        widget, showDelay=int(show_delay_ms), position=position
+    )
+    widget.installEventFilter(tooltip_filter)
+    widget._cgs_fluent_tooltip_filters = [tooltip_filter]
 
 
 def configure_tray_qt_fonts(app: QApplication) -> None:

--- a/utils/config/qc.py
+++ b/utils/config/qc.py
@@ -29,7 +29,7 @@ class CgsConfig(QConfig):
     subscribeWinRect = ConfigItem("SubscribeWindow", "Rect", [], restart=False)
     # Active subscription binding profile (subscription_{name}.yml); tray + GUI share this.
     activeSubscriptionCustomname = ConfigItem("Subscription", "ActiveCustomname", "default", restart=False)
-    # Global catch-up (后巡查) cadence for tray Schedule — off|12h|daily|2d|weekly.
+    # Global catch-up (后巡查) cadence for tray Schedule — off|3h|12h|daily|2d.
     subscriptionCatchupPreset = ConfigItem("Subscription", "CatchupPreset", "off", restart=False)
     hiddenSiteChoices = ConfigItem("MainWindow", "HiddenSiteChoices", [], restart=False)
     doh: "CgsConfig.DoH"

--- a/utils/middleware/presets/d2_episode_diff.py
+++ b/utils/middleware/presets/d2_episode_diff.py
@@ -1,13 +1,18 @@
 # -*- coding: utf-8 -*-
-"""D2 — Episode Diff (Lane D filter, mode-agnostic).
+"""D2 — Episode Diff (Lane D filter, HWM-forward update).
 
-Honors invariant I5 — broadcaster and subscriber share identical diff semantics;
-mode difference lives only in HOW BookInfo enters the lane (B/C skip strategy).
+Honors invariant I5-R — source-agnostic HWM-forward 追更 filter.
+Own books and follow-pulled books share identical semantics; only HOW BookInfo
+enters the lane differs.
 
-Pure filter primitive `filter_undownloaded` is exposed for unit-testing without
+Pure filter primitive `filter_hwm_forward` is exposed for unit-testing without
 GUI/SQL dependencies; the `D2EpisodeDiff` middleware is a thin context shim that
 mutates `ctx.eps` in place and returns no Action (so downstream selectors like
 AutoSelectLatest see the narrowed set).
+
+Product meaning: schedule 追更 keeps only episodes newer than local HWM
+(`dl_max`), not every undownloaded chapter under the mark. See
+`.trellis/spec/cgs-subscribe/update-semantics.md`.
 """
 from __future__ import annotations
 
@@ -41,34 +46,38 @@ def _section_num(name: t.Optional[str]) -> t.Optional[float]:
         return None
 
 
-def filter_undownloaded(
+def filter_hwm_forward(
     site_episodes: t.Iterable,
     dl_max: str = "",
     downloaded_md5s: t.Optional[t.Set[str]] = None,
 ) -> list:
-    """Return site episodes not yet downloaded locally.
+    """Return site episodes strictly newer than local HWM (schedule 追更 set).
 
-    Pipeline (I5 semantics):
+    Pipeline (I5-R / update-semantics):
       1. Drop episodes whose md5 already lives in `downloaded_md5s` (exact dedup).
-      2. Drop episodes whose section number <= `dl_max`'s section number (ordinal cut).
+      2. Drop episodes whose section number <= `dl_max`'s section number (HWM cut).
       3. Episodes without a parseable section number are kept conservatively
          (better to re-fetch than silently miss a new ep with an unusual name).
       4. Ordering of the input iterable is preserved in the output.
 
-    Edge cases (I5 Validation Matrix):
+    This is **not** a completeness diff: holes under HWM stay out of the result
+    even when those files are absent on disk (e.g. local 9–10, site 1–12 → 11–12).
+
+    Edge cases:
       - Empty input -> [].
-      - Empty/None dl_max -> ordinal cut is skipped; only md5 dedup applies.
-      - dl_max parses but is >= every site section -> [] (treated as fully local).
-      - dl_max is unparseable -> log warn and skip ordinal cut (do not crash).
+      - Empty/None dl_max -> HWM cut is skipped; only md5 dedup applies.
+      - dl_max parses but is >= every site section -> [] (nothing newer than HWM).
+      - dl_max is unparseable -> log warn and skip HWM cut (do not crash).
 
     Args:
         site_episodes: iterable of objects with `.name` (str) and ideally
             `.id_and_md5() -> (uid, md5)` for the dedup step.
-        dl_max: highest locally-downloaded section name for the book.
+        dl_max: highest locally-downloaded section name for the book (HWM label).
         downloaded_md5s: optional precomputed md5 set; if None, dedup is skipped.
 
     Returns:
-        Filtered list preserving original order.
+        Filtered list preserving original order (forward-of-HWM candidates only
+        when `dl_max` parses).
     """
     eps = [ep for ep in site_episodes if ep is not None]
     if not eps:
@@ -89,7 +98,7 @@ def filter_undownloaded(
     if dl_max:
         cutoff = _section_num(dl_max)
         if cutoff is None:
-            _log.warning("D2: dl_max=%r has no parseable section number; ordinal cut skipped", dl_max)
+            _log.warning("D2: dl_max=%r has no parseable section number; HWM cut skipped", dl_max)
 
     kept: list = []
     for ep in eps:
@@ -104,10 +113,14 @@ def filter_undownloaded(
     return kept
 
 
-class D2EpisodeDiff:
-    """Lane D middleware: filters `ctx.eps` to undownloaded episodes only.
+# Legacy alias — do not use in new code; name implied completeness-diff / gap-fill.
+filter_undownloaded = filter_hwm_forward
 
-    Mode-agnostic (I5). Mutates `ctx.eps` in place and returns no Action so the
+
+class D2EpisodeDiff:
+    """Lane D middleware: filters `ctx.eps` to HWM-forward update episodes.
+
+    Source-agnostic (I5-R). Mutates `ctx.eps` in place and returns no Action so the
     chain continues (downstream auto-selectors see the narrowed dict).
 
     Providers are injected to keep this preset GUI/SQL-free:
@@ -143,7 +156,7 @@ class D2EpisodeDiff:
         md5s_iter = self._md5s_provider(ctx, ordered_eps) if self._md5s_provider else ()
         md5_set = set(md5s_iter or ())
 
-        kept_eps = filter_undownloaded(ordered_eps, dl_max=dl_max or "", downloaded_md5s=md5_set)
+        kept_eps = filter_hwm_forward(ordered_eps, dl_max=dl_max or "", downloaded_md5s=md5_set)
         if len(kept_eps) == len(ordered_eps):
             return None  # nothing to drop; do not mutate ctx
 

--- a/utils/script/aria2/bootstrap.py
+++ b/utils/script/aria2/bootstrap.py
@@ -14,10 +14,14 @@ from typing import Any
 from loguru import logger
 
 from deploy import curr_os
+from utils.config import conf_dir
 from utils.preset_assets import managed_asset_sources
 
 ARIA2_MANIFEST_NAME = "aria2-manifest.json"
 SUPPORTED_PLATFORM_IDS = frozenset({"win-amd64", "macos-arm"})
+# Runtime binary is user data (conf_dir), not package content (site-packages/__temp).
+# Separates "app install replace" from "engine binary lifetime" — Single Owner.
+ARIA2_BIN_DIRNAME = "bin"
 # Binary payload may be multi‑MB; keep a longer ceiling.
 BINARY_DOWNLOAD_TIMEOUT_S = 120
 # Manifest is tiny JSON. MUST NOT reuse binary timeout — a hung GitHub TCP
@@ -55,11 +59,11 @@ def detect_aira2_platform_id() -> str:
 
 
 def aira2_install_dir() -> Path:
-    return Path(curr_os.aira2).parent
+    return conf_dir.joinpath("cgs-aria2", ARIA2_BIN_DIRNAME)
 
 
 def resolve_aira2_target_path() -> Path:
-    return Path(curr_os.aira2)
+    return aira2_install_dir().joinpath(curr_os.aira2_binary_name)
 
 
 def file_sha256(path: Path) -> str:
@@ -236,10 +240,10 @@ def local_binary_present(target_path: Path | None = None) -> bool:
 
 
 def ensure_aira2_binary(*, progress_callback=None, force_refresh: bool = False) -> Path:
-    """Ensure curr_os.aira2 exists. No PATH/uv/runtime fallback.
+    """Ensure managed aria2c under conf_dir/cgs-aria2/bin. No PATH/uv/runtime fallback.
 
     Local-first (critical for Script preprocess latency):
-    - If ``curr_os.aira2`` already exists and ``force_refresh`` is false, return it
+    - If the managed binary already exists and ``force_refresh`` is false, return it
       immediately with **zero** network. Installer trees and second opens must not
       block on GitHub/ImgBed manifest (previously hung up to BINARY timeout ≈ 2min).
     - Only when the binary is missing (or ``force_refresh``) fetch manifest + payload.
@@ -292,7 +296,7 @@ def ensure_aira2_binary(*, progress_callback=None, force_refresh: bool = False) 
 
 
 def copy_local_preset_asset_into_tree(source_binary: Path, *, platform_id: str | None = None) -> Path:
-    """Dev/CI helper: place a pre-fetched binary at curr_os.aira2 without network (still no PATH)."""
+    """Dev/CI helper: place a pre-fetched binary at conf_dir/cgs-aria2/bin without network."""
     resolved_platform = platform_id or detect_aira2_platform_id()
     if resolved_platform not in SUPPORTED_PLATFORM_IDS:
         raise UnsupportedAria2PlatformError(resolved_platform)

--- a/utils/script/aria2/engine.py
+++ b/utils/script/aria2/engine.py
@@ -235,7 +235,7 @@ def pick_free_port(host: str = "127.0.0.1") -> int:
 
 
 def resolve_aria2_binary(*, progress_callback=None) -> p.Path:
-    """Resolve managed binary only via preset → temp_p/aira2 (no PATH/uv/runtime fallback)."""
+    """Resolve managed binary only via preset → conf_dir/cgs-aria2/bin (no PATH/uv fallback)."""
     return ensure_aira2_binary(progress_callback=progress_callback)
 
 

--- a/utils/server_control.py
+++ b/utils/server_control.py
@@ -300,14 +300,26 @@ class ServerLauncher:
                 time.sleep(0.1)
 
     def _launch_and_wait(self) -> ServerEndpoint:
-        from utils.config import env, exc_p
+        from utils.config import exc_p
         from variables import VER
 
         self.log_path.parent.mkdir(parents=True, exist_ok=True)
+        # Truncate boot log so failure messages never surface a previous run's
+        # "No module named server.main" as if it belonged to this spawn.
+        try:
+            self.boot_log_path.write_bytes(b"")
+        except OSError:
+            pass
+        child_env = _server_child_env()
         try:
             with open(self.boot_log_path, "wb") as log_file:
                 self.process = subprocess.Popen(
-                    self.command, cwd=str(exc_p), env=env, stdout=log_file, stderr=subprocess.STDOUT, **_popen_kwargs()
+                    self.command,
+                    cwd=str(exc_p),
+                    env=child_env,
+                    stdout=log_file,
+                    stderr=subprocess.STDOUT,
+                    **_popen_kwargs(),
                 )
         except OSError as exc:
             raise ServerLaunchError(self._failure_message("cgs-server launch failed")) from exc
@@ -317,7 +329,10 @@ class ServerLauncher:
         while time.monotonic() < deadline:
             if self.process.poll() is not None:
                 raise ServerLaunchError(
-                    self._failure_message(f"cgs-server exited with code {self.process.returncode}", timeout=self.timeout)
+                    self._failure_message(
+                        f"cgs-server exited with code {self.process.returncode}",
+                        timeout=self.timeout,
+                    )
                 )
             try:
                 endpoint = resolve_server_endpoint(
@@ -500,6 +515,41 @@ def _server_python() -> Path:
         if venv_python.exists():
             return venv_python
     return Path(sys.executable)
+
+
+def _server_child_env() -> dict[str, str]:
+    """Env for the tray-host child process.
+
+    - Pins ``PYTHONPATH`` to the repo root so ``python -m server.main`` works even
+      when editable-install metadata is broken or the parent shell polluted path.
+    - Sets ``CGS_SERVER_FORCE_HOST=1`` so the child always hosts tray/HTTP instead
+      of resolving a peer endpoint and exiting 0 (parent would then report
+      "exited with code 0 / no tray-hosted discovery").
+    - Drops test-only env vars that must not leak into the long-lived server.
+    """
+    from utils.config import env, exc_p
+
+    child: dict[str, str] = {str(key): str(value) for key, value in env.items() if value is not None}
+    repo_root = str(Path(exc_p).resolve())
+    path_parts: list[str] = [repo_root]
+    existing_pythonpath = str(child.get("PYTHONPATH") or "").strip()
+    if existing_pythonpath:
+        for fragment in existing_pythonpath.split(os.pathsep):
+            cleaned = str(fragment or "").strip()
+            if cleaned and cleaned not in path_parts:
+                path_parts.append(cleaned)
+    child["PYTHONPATH"] = os.pathsep.join(path_parts)
+    child["CGS_SERVER_FORCE_HOST"] = "1"
+    for key in list(child.keys()):
+        upper = key.upper()
+        if upper.startswith("CGS_TEST") or upper in {
+            "CGS_TEST_AUTORUN",
+            "CGS_TT_TRAY_WORKER",
+            "CGS_TT_YML_TRAY_WORKER",
+            "CGS_REAL_SUBSCRIPTION_YML",
+        }:
+            child.pop(key, None)
+    return child
 
 
 def _popen_kwargs() -> dict:

--- a/utils/subscription/__init__.py
+++ b/utils/subscription/__init__.py
@@ -60,6 +60,7 @@ from utils.subscription.store import (
     get_subscription_catchup_preset,
     list_subscription_customnames,
     open_active_subscription_store,
+    remove_yaml_book,
     set_active_subscription_customname,
     set_subscription_catchup_preset,
 )
@@ -110,6 +111,7 @@ __all__ = [
     "list_subscription_customnames",
     "normalize_tz_offset",
     "open_active_subscription_store",
+    "remove_yaml_book",
     "resolve_default_weekdays",
     "set_active_subscription_customname",
     "set_subscription_catchup_preset",

--- a/utils/subscription/library.py
+++ b/utils/subscription/library.py
@@ -69,12 +69,10 @@ class LibraryBookView:
 
     @staticmethod
     def book_from_entry(entry: BookEntry):
-        from utils.website.info import BookInfo
+        # Site-typed BookInfo (Manga/Ero) so tray providers can set img_preview etc.
+        from utils.tray.subscription_book_resolve import book_from_entry as construct_site_book
 
-        site = str(entry.site or "").strip()
-        url = str(entry.url or "").strip()
-        title = str(entry.title or "").strip() or url
-        book = BookInfo(id=url, source=site, url=url, preview_url=url, name=title)
+        book = construct_site_book(entry)
         setattr(book, "subscribe_enabled", bool(entry.enabled))
         return book
 
@@ -171,6 +169,8 @@ class YamlBookOverlay:
             seen.add(key)
             yaml_entry = yaml_by_key.get(key)
             if yaml_entry is not None:
+                if yaml_entry.title:
+                    entry.title = str(yaml_entry.title).strip()
                 entry.enabled = bool(yaml_entry.enabled)
                 if yaml_entry.check is not None:
                     entry.check = yaml_entry.check.copy()

--- a/utils/subscription/schema.py
+++ b/utils/subscription/schema.py
@@ -15,6 +15,7 @@ VALID_INTERVAL_PRESETS = frozenset({"never", "12h", "daily", "2d", "weekly", "ma
 PRESET_INTERVAL_HOURS: dict[str, Optional[int]] = {
     "never": None,
     "off": None,
+    "3h": 3,
     "12h": 12,
     "daily": 24,
     "2d": 48,
@@ -23,14 +24,19 @@ PRESET_INTERVAL_HOURS: dict[str, Optional[int]] = {
 }
 DAY_ALIGNED_PRESETS = frozenset({"daily", "2d", "weekly"})
 
-VALID_CATCHUP_PRESETS = frozenset({"off", "12h", "daily", "2d", "weekly"})
+# Tray-global 后巡查 only (not SidePanel interval). No weekly — too sparse for catch-up.
+VALID_CATCHUP_PRESETS = frozenset({"off", "3h", "12h", "daily", "2d"})
 CATCHUP_PRESET_ITEMS = (
     ("off", "关闭"),
+    ("3h", "每3小时"),
     ("12h", "每12小时"),
     ("daily", "每天"),
     ("2d", "每2天"),
-    ("weekly", "每周"),
 )
+# Legacy qconfig values map into the current catch-up set.
+CATCHUP_PRESET_LEGACY_ALIASES = {
+    "weekly": "2d",
+}
 
 VALID_WEEKDAY_IDS = frozenset({"1", "2", "3", "4", "5", "6", "7"})
 ALL_WEEKDAYS = ("1", "2", "3", "4", "5", "6", "7")

--- a/utils/subscription/store.py
+++ b/utils/subscription/store.py
@@ -118,8 +118,14 @@ class BindingRepository:
             raise ValueError("subscription payload must be a mapping")
         path = self.path_for(customname)
         path.parent.mkdir(parents=True, exist_ok=True)
-        with open(path, "w", encoding="utf-8") as handle:
-            yaml.safe_dump(payload, handle, allow_unicode=True, sort_keys=False)
+        temporary_path = path.with_name(f"{path.name}.tmp")
+        try:
+            with open(temporary_path, "w", encoding="utf-8") as handle:
+                yaml.safe_dump(payload, handle, allow_unicode=True, sort_keys=False)
+            temporary_path.replace(path)
+        except Exception:
+            temporary_path.unlink(missing_ok=True)
+            raise
 
 
 class SubscriptionStore:
@@ -192,6 +198,33 @@ class SubscriptionStore:
         self._repository.write_mapping(self.customname, self._codec.encode(config))
 
 
+def remove_yaml_book(config: SubscriptionConfig, site: str, url: str) -> bool:
+    """Drop the first ``books[]`` row matching site+url.
+
+    Mutates ``config.books`` in place. Returns True when a row was removed.
+    Does not persist — caller owns ``SubscriptionStore.save``.
+    """
+    if config is None:
+        raise TypeError("remove_yaml_book requires a SubscriptionConfig")
+    site_key = str(site or "").strip()
+    url_key = str(url or "").strip()
+    if not url_key:
+        return False
+    match_index = next(
+        (
+            index
+            for index, entry in enumerate(config.books or [])
+            if str(getattr(entry, "url", "") or "").strip() == url_key
+            and str(getattr(entry, "site", "") or "").strip() == site_key
+        ),
+        None,
+    )
+    if match_index is None:
+        return False
+    del config.books[match_index]
+    return True
+
+
 class BindingProfileCatalog:
     """Profile names under the binding directory + active profile pointer."""
 
@@ -262,13 +295,19 @@ class CatchupPresetSetting:
         self._writer = writer or self._write_to_qconfig
 
     def get(self) -> str:
+        from utils.subscription.schema import CATCHUP_PRESET_LEGACY_ALIASES, VALID_CATCHUP_PRESETS
+
         raw = str(self._reader() or "off").strip() or "off"
+        raw = CATCHUP_PRESET_LEGACY_ALIASES.get(raw, raw)
         if raw not in VALID_CATCHUP_PRESETS:
             return "off"
         return raw
 
     def set(self, preset: str) -> str:
+        from utils.subscription.schema import CATCHUP_PRESET_LEGACY_ALIASES, VALID_CATCHUP_PRESETS
+
         name = str(preset or "off").strip() or "off"
+        name = CATCHUP_PRESET_LEGACY_ALIASES.get(name, name)
         if name not in VALID_CATCHUP_PRESETS:
             raise ValueError(f"invalid catchup preset: {preset!r}")
         self._writer(name)

--- a/utils/tray/__init__.py
+++ b/utils/tray/__init__.py
@@ -1,13 +1,19 @@
 from __future__ import annotations
 
 from utils.tray.event_log import TrayEventLog
-from utils.tray.subscription_scheduler import ScheduleDecision, ScheduleStatus, SubscriptionScheduler
+from utils.tray.subscription_scheduler import (
+    ScheduleDecision,
+    ScheduleStatus,
+    SubscriptionScheduler,
+    schedule_run_scope,
+)
 
 __all__ = [
     "TrayEventLog",
     "ScheduleDecision",
     "ScheduleStatus",
     "SubscriptionScheduler",
+    "schedule_run_scope",
     "SubscriptionRunner",
     "SubscriptionRunSummary",
 ]

--- a/utils/tray/schedule_presentation.py
+++ b/utils/tray/schedule_presentation.py
@@ -9,7 +9,6 @@ from typing import Any, Iterable, Optional
 from utils import temp_p
 from utils.share.serializer import deserialize_books, serialize_books
 from utils.subscription.schema import BookEntry, FeatureEntry, FollowEntry, SubscriptionConfig
-from utils.subscription.library import LocalLibraryStore
 from utils.tray.feature_search import feature_status, supported_features, unsupported_feature_summary, unsupported_features
 
 SCHEDULE_PRESENTATION_SCHEMA = 1
@@ -55,6 +54,8 @@ class SchedulePendingItemRow:
     message: str = ""
     cover_url: str = ""
     source_url: str = ""
+    local_path: str = ""
+    local_cover_path: str = ""
 
 
 @dataclass(frozen=True)
@@ -216,8 +217,8 @@ def build_schedule_presentation(
         config_owner = f"subscription binding «{profile}» (tray executes)"
     schedule_cache = cache or ScheduleCache()
     plan = _build_plan(cfg, status=status, blocker=blocker, config_owner=config_owner)
-    sources = _source_rows(cfg)
     pending_items = _pending_rows(cache_summary)
+    sources = _source_rows(cfg, pending_items=pending_items)
     history = [_history_row(event) for event in events]
     cache_state = schedule_cache.state_from_summary(cache_summary)
     run_view = run or _run_from_summary(cache_summary)
@@ -235,6 +236,8 @@ def build_schedule_presentation(
             "cache": asdict(cache_state),
             "run": asdict(run_view),
             "summary": cache_summary or {},
+            "binding_books": len(cfg.books),
+            "binding_enabled_books": len([entry for entry in cfg.books if entry.enabled]),
         },
     )
 
@@ -242,7 +245,8 @@ def build_schedule_presentation(
 def _build_plan(cfg: SubscriptionConfig, *, status, blocker: str, config_owner: str) -> SchedulePlanView:
     next_run = getattr(status, "next_run_at", None)
     next_run_at = next_run.isoformat(timespec="minutes") if next_run is not None else "-"
-    enabled_books = len(LocalLibraryStore().book_entries())
+    # Counts must match the active subscription_*.yml binding, not whole-library bookmarks.
+    enabled_books = len([entry for entry in cfg.books if entry.enabled])
     enabled_features = len([entry for entry in cfg.features if entry.enabled])
     follows = len(cfg.follows)
     config_blocker, blocker_action = _config_blocker(cfg)
@@ -290,10 +294,23 @@ def _format_plan_timing(cfg: SubscriptionConfig) -> str:
     )
 
 
-def _source_rows(cfg: SubscriptionConfig) -> list[ScheduleSourceRow]:
+def _source_rows(
+    cfg: SubscriptionConfig,
+    *,
+    pending_items: Optional[list[SchedulePendingItemRow]] = None,
+) -> list[ScheduleSourceRow]:
+    """Schedule objects = active binding yaml books/features/follows only."""
     rows: list[ScheduleSourceRow] = []
-    for index, entry in enumerate(LocalLibraryStore().book_entries(), start=1):
-        rows.append(_book_source_row(index, entry))
+    pending_by_source = _pending_count_by_source(pending_items or [])
+    for index, entry in enumerate(cfg.books, start=1):
+        rows.append(
+            _book_source_row(
+                index,
+                entry,
+                profile_check=cfg.check,
+                pending_by_source=pending_by_source,
+            )
+        )
     for index, entry in enumerate(cfg.features, start=1):
         rows.append(_feature_source_row(index, entry))
     for index, entry in enumerate(cfg.follows, start=1):
@@ -301,15 +318,55 @@ def _source_rows(cfg: SubscriptionConfig) -> list[ScheduleSourceRow]:
     return rows
 
 
-def _book_source_row(index: int, entry: BookEntry) -> ScheduleSourceRow:
+def _pending_count_by_source(pending_items: list[SchedulePendingItemRow]) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for item in pending_items:
+        key = str(item.source_id or "").strip()
+        if not key:
+            site = str(item.site or "").strip()
+            title = str(item.title or "").strip()
+            key = f"title:{site}:{title}" if site or title else ""
+        if not key:
+            continue
+        counts[key] = counts.get(key, 0) + 1
+    return counts
+
+
+def _book_source_row(
+    index: int,
+    entry: BookEntry,
+    *,
+    profile_check,
+    pending_by_source: Optional[dict[str, int]] = None,
+) -> ScheduleSourceRow:
+    source_id = f"book:{entry.site}:{entry.url}"
+    # Always surface the effective CheckSlot (card override or profile default).
+    # ``latest`` is reserved for 刊期 fingerprint — not pending-chapter counts.
+    try:
+        slot = entry.effective_slot(profile_check)
+        latest = slot.fingerprint() if slot is not None else ""
+    except Exception:
+        latest = ""
+    pending_count = 0
+    if pending_by_source:
+        pending_count = int(pending_by_source.get(source_id, 0))
+        if pending_count <= 0:
+            pending_count = int(
+                pending_by_source.get(
+                    f"title:{str(entry.site or '').strip()}:{str(entry.title or '').strip()}",
+                    0,
+                )
+            )
     return ScheduleSourceRow(
-        source_id=f"book:{index}:{entry.site}:{entry.url}",
+        source_id=source_id or f"book:{index}:{entry.site}:{entry.url}",
         kind="book",
         site=str(entry.site or ""),
         title=str(entry.title or ""),
         enabled=bool(entry.enabled),
         locator=_tail(str(entry.url or "")),
         status="enabled" if entry.enabled else "disabled",
+        latest=latest,
+        pending_count=pending_count,
     )
 
 
@@ -348,21 +405,113 @@ def _pending_rows(summary: Optional[dict[str, Any]]) -> list[SchedulePendingItem
     for item in raw_items:
         if not isinstance(item, dict):
             raise ScheduleCacheError("schedule summary pending item must be a mapping")
+        # Runner historically wrote ``book``; presentation reads ``title``.
+        title = str(item.get("title") or item.get("book") or "")
+        site = str(item.get("site") or "")
+        source_url = str(item.get("source_url") or item.get("url") or "")
+        source_id = str(item.get("source_id") or "")
+        if not source_id and site and source_url:
+            source_id = f"book:{site}:{source_url}"
+        episode = str(item.get("episode") or "")
+        local_path = str(item.get("local_path") or "").strip()
+        # Prefer live chapter-dir resolve; drop stale book-root paths from old runs.
+        resolved = _resolve_download_local_path(title, episode)
+        if resolved:
+            local_path = resolved
+        elif local_path and not _is_chapter_local_path(local_path, title, episode):
+            local_path = ""
+        # Disk chapter dir is the only authority for "已下载". Stale summary
+        # status/local_path must not keep items finished without a chapter folder.
+        if local_path and Path(local_path).is_dir():
+            status = "finished"
+        else:
+            status = "queued"
+        local_cover = str(item.get("local_cover_path") or item.get("cover_path") or "").strip()
+        if not local_cover and local_path:
+            local_cover = _first_local_cover_file(local_path)
+        cover_url = str(item.get("cover_url") or item.get("img_preview") or "").strip()
         rows.append(
             SchedulePendingItemRow(
                 item_id=str(item.get("item_id") or ""),
-                source_id=str(item.get("source_id") or ""),
-                site=str(item.get("site") or ""),
-                title=str(item.get("title") or ""),
-                episode=str(item.get("episode") or ""),
-                status=str(item.get("status") or "pending"),
+                source_id=source_id,
+                site=site,
+                title=title,
+                episode=episode,
+                status=status,
                 stage=str(item.get("stage") or ""),
                 message=str(item.get("message") or ""),
-                cover_url=str(item.get("cover_url") or ""),
-                source_url=str(item.get("source_url") or ""),
+                cover_url=local_cover or cover_url,
+                source_url=source_url,
+                local_path=local_path,
+                local_cover_path=local_cover,
             )
         )
     return rows
+
+
+def _resolve_download_local_path(title: str, episode: str) -> str:
+    """Map book+episode onto conf.sv_path chapter folder only.
+
+    Returns empty when the chapter directory is missing. Never returns the book
+    root alone — that falsely marks every episode as downloaded.
+    """
+    from utils import conf
+    from utils.core import sanitize_for_path
+
+    book_title = str(title or "").strip()
+    episode_name = str(episode or "").strip()
+    if not book_title or not episode_name:
+        return ""
+    root = Path(getattr(conf, "sv_path", "") or "")
+    if not root:
+        return ""
+    episode_dir = root.joinpath(sanitize_for_path(book_title), sanitize_for_path(episode_name))
+    if episode_dir.is_dir():
+        return str(episode_dir)
+    return ""
+
+
+def _is_chapter_local_path(local_path: str, title: str, episode: str) -> bool:
+    """True only when path looks like .../<book>/<episode>, not the book root."""
+    path = Path(str(local_path or "").strip())
+    if not path.is_dir():
+        return False
+    episode_name = str(episode or "").strip()
+    if not episode_name:
+        return False
+    from utils.core import sanitize_for_path
+
+    return path.name == sanitize_for_path(episode_name) or path.name == episode_name
+
+
+def _first_local_cover_file(local_path: str) -> str:
+    root = Path(local_path)
+    if not root.is_dir():
+        return ""
+    suffixes = {".jpg", ".jpeg", ".png", ".webp", ".avif", ".gif", ".bmp"}
+    preferred_names = (
+        "1.jpg",
+        "1.jpeg",
+        "1.png",
+        "01.jpg",
+        "001.jpg",
+        "cover.jpg",
+        "cover.png",
+        "front.jpg",
+    )
+    for name in preferred_names:
+        candidate = root / name
+        if candidate.is_file():
+            return str(candidate)
+    try:
+        files = sorted(
+            path
+            for path in root.iterdir()
+            if path.is_file() and path.suffix.lower() in suffixes
+        )
+    except OSError:
+        return ""
+    return str(files[0]) if files else ""
 
 
 def _run_from_summary(summary: Optional[dict[str, Any]]) -> ScheduleRunView:
@@ -414,10 +563,14 @@ def _config_blocker(cfg: SubscriptionConfig) -> tuple[str, str]:
     unsupported = unsupported_features(cfg.features)
     if unsupported:
         return f"有暂不支持后台扫描的作者/标签特征：{unsupported_feature_summary(unsupported)}", "停用这些特征，或改为添加明确作品追更。"
-    enabled_books = len(LocalLibraryStore().book_entries())
+    enabled_books = len([entry for entry in cfg.books if entry.enabled])
     supported = supported_features(cfg.features)
     if enabled_books <= 0 and not supported and not cfg.follows:
-        return "没有启用的追更对象", "从预览页勾选作品加入追更，或在主窗口追更配置里启用已有对象。"
+        return (
+            "当前 binding 的 yml 没有启用书",
+            "在追更工作台 SidePanel 启用作品并保存周期到 subscription_*.yml；"
+            "tray 只执行 yml 绑定，不会扫描整库收藏。",
+        )
     return "", ""
 
 

--- a/utils/tray/subscription_book_resolve.py
+++ b/utils/tray/subscription_book_resolve.py
@@ -208,6 +208,33 @@ class BookTypeRegistry:
             book, site=site, entry_url=url, reconstruct=True
         )
 
+    @classmethod
+    def upgrade_library_shell(cls, shell: BookInfo, entry: BookEntry) -> BookInfo:
+        """Rebuild a bare BookInfo pickle as the site type, preserving runtime fields.
+
+        Bare ``BookInfo`` shells are only seeded while the site type is unknown;
+        the typed object owns provider fields (``img_preview``, ``episodes``, ...).
+        Identity fields come from the entry when the shell has no value, and
+        runtime fields are carried over as a single constructor payload.
+        """
+        if type(shell) is not BookInfo:
+            return shell
+        site = str(entry.site or "").strip()
+        book_type = cls.book_type_for(site)
+        if book_type is BookInfo:
+            return shell
+        payload = {
+            "id": getattr(shell, "id", "") or extract_book_id(site, entry.url) or str(entry.url or "").strip(),
+            "source": None,
+            "url": getattr(shell, "url", "") or str(entry.url or "").strip(),
+            "preview_url": getattr(shell, "preview_url", "") or str(entry.url or "").strip(),
+            "name": getattr(shell, "name", "") or str(entry.title or "").strip(),
+            "img_preview": getattr(shell, "img_preview", None),
+            "latest_sec": getattr(shell, "latest_sec", None),
+            "episodes": getattr(shell, "episodes", None) or [],
+        }
+        return book_type(**payload)
+
 
 class BookInfoResolver:
     """Resolve BookEntry → BookInfo: local library pickle, else yaml construct."""
@@ -244,6 +271,7 @@ class BookInfoResolver:
 
     def _hydrate_library_book(self, book: BookInfo, entry: BookEntry, target_url: str) -> BookInfo:
         site = str(entry.site or "").strip()
+        book = BookTypeRegistry.upgrade_library_shell(book, entry)
         if not str(getattr(book, "source", "") or "").strip():
             setattr(book, "source", site)
         if not str(getattr(book, "name", "") or "").strip() and entry.title:

--- a/utils/tray/subscription_runner.py
+++ b/utils/tray/subscription_runner.py
@@ -108,9 +108,24 @@ class SubscriptionRunSummary:
 
     @property
     def message(self) -> str:
+        # ``pending_episodes`` is D2 raw length; banner must distinguish still-queued
+        # vs already-on-disk so "已下载" items are not reported as pending forever.
+        queued = sum(
+            1
+            for item in self.pending_items
+            if str(item.get("status") or "").strip().casefold() in {"", "queued", "pending", "diff"}
+        )
+        finished = sum(
+            1
+            for item in self.pending_items
+            if str(item.get("status") or "").strip().casefold()
+            in {"finished", "done", "complete", "completed", "ok", "submitted"}
+            or bool(str(item.get("local_path") or "").strip())
+        )
         parts = [
             f"books={self.scanned_books}",
-            f"pending={self.pending_episodes}",
+            f"queued={queued}",
+            f"downloaded={finished}",
             f"jobs={self.submitted_jobs}",
         ]
         if self.follow_books:
@@ -221,8 +236,15 @@ class SubscriptionRunner:
             return set(self._md5s_provider(entry, books) or set())
         return set(self._download_state.downloaded_md5s(books))
 
-    def run_once(self, *, trigger: str = "schedule") -> SubscriptionRunSummary:
-        return asyncio.run(self.run_once_async(trigger=trigger))
+    def run_once(
+        self,
+        *,
+        trigger: str = "schedule",
+        selected_books: Optional[list[BookEntry] | tuple[BookEntry, ...]] = None,
+    ) -> SubscriptionRunSummary:
+        return asyncio.run(
+            self.run_once_async(trigger=trigger, selected_books=selected_books)
+        )
 
     def load_config(self) -> SubscriptionConfig:
         if self._config_loader is not None:
@@ -234,12 +256,19 @@ class SubscriptionRunner:
         if callable(close):
             close()
 
-    async def run_once_async(self, *, trigger: str = "schedule") -> SubscriptionRunSummary:
+    async def run_once_async(
+        self,
+        *,
+        trigger: str = "schedule",
+        selected_books: Optional[list[BookEntry] | tuple[BookEntry, ...]] = None,
+    ) -> SubscriptionRunSummary:
         started_at = _utc_ts()
         started = time.monotonic()
         cfg = self.load_config()
         cfg.validate()
-        summary = await _RunSession(self, cfg, trigger).execute()
+        summary = await _RunSession(
+            self, cfg, trigger, selected_books=selected_books
+        ).execute()
         summary.started_at = started_at
         summary.finished_at = _utc_ts()
         summary.elapsed_sec = round(time.monotonic() - started, 3)
@@ -283,11 +312,21 @@ class SubscriptionRunner:
 class _RunSession:
     """One subscription cycle: ordered stages over shared mutable context."""
 
-    def __init__(self, runner: SubscriptionRunner, cfg: SubscriptionConfig, trigger: str) -> None:
+    def __init__(
+        self,
+        runner: SubscriptionRunner,
+        cfg: SubscriptionConfig,
+        trigger: str,
+        *,
+        selected_books: Optional[list[BookEntry] | tuple[BookEntry, ...]] = None,
+    ) -> None:
         self.runner = runner
         self.cfg = cfg
         self.trigger = trigger
         self.manual = trigger == "manual"
+        self.selected_books = (
+            tuple(selected_books) if selected_books is not None else None
+        )
         self.now = runner._now_provider()
         self.summary = SubscriptionRunSummary(trigger=trigger, stage="Config")
         self.book_entries: list[BookEntry] = []
@@ -322,18 +361,23 @@ class _RunSession:
                 f"unsupported feature tracking: {unsupported_feature_summary(unsupported)}"
             )
         if self.cfg.books:
+            # Keep library pkl in sync for covers / resolve, but scan scope is binding yaml.
             self.runner._library_store.ensure_books_from_yaml(self.cfg.books)
+        # Schedule scan SSoT = active subscription_*.yml books[], not whole local library.
+        from utils.tray.subscription_scheduler import schedule_binding_book_entries
+
         enabled = [
-            entry
-            for entry in self.runner._library_store.book_entries(yaml_books=self.cfg.books)
-            if entry.enabled
+            entry for entry in schedule_binding_book_entries(self.cfg) if entry.enabled
         ]
         # D-w6: Layer C is_due is NOT the primary due gate. State still loads for writeback.
         self.states = self.runner._check_state_store.load()
-        self.book_entries = (
-            enabled
-            if self.manual
-            else _filter_books_for_trigger(enabled, self.cfg, self.now, trigger=self.trigger)
+        self.book_entries = _resolve_scan_book_entries(
+            enabled,
+            self.cfg,
+            self.now,
+            trigger=self.trigger,
+            selected_books=self.selected_books,
+            manual=self.manual,
         )
         self.feature_entries = supported_features(self.cfg.features)
         self.checkin_states = self.runner._checkin_state_store.load()
@@ -831,6 +875,58 @@ def _follow_seen_key(book: BookInfo) -> str:
     return f"follow-book:{_book_site_key(book)}:{getattr(book, 'url', '')}"
 
 
+def _book_entry_identity(entry: BookEntry) -> str:
+    return f"{str(entry.site or '').strip()}:{str(entry.url or '').strip()}"
+
+
+def _resolve_scan_book_entries(
+    enabled_entries: list[BookEntry],
+    cfg: SubscriptionConfig,
+    now: datetime,
+    *,
+    trigger: str,
+    selected_books: Optional[tuple[BookEntry, ...]],
+    manual: bool,
+) -> list[BookEntry]:
+    """Pick this-run own books.
+
+    Priority:
+    1. explicit ``selected_books`` from ScheduleDecision.matched_books (primary path)
+    2. manual / catchup / generic schedule → all enabled
+    3. primary-like trigger text → enabled ∩ effective_slot.matches (legacy / tests)
+    """
+    if selected_books is not None:
+        return _intersect_selected_with_enabled(enabled_entries, selected_books)
+    if manual:
+        return list(enabled_entries)
+    return _filter_books_for_trigger(
+        enabled_entries, cfg, now, trigger=trigger
+    )
+
+
+def _intersect_selected_with_enabled(
+    enabled_entries: list[BookEntry],
+    selected_books: tuple[BookEntry, ...],
+) -> list[BookEntry]:
+    """Keep scheduler order; only scan books still enabled in the live yaml binding."""
+    enabled_by_key = {
+        _book_entry_identity(entry): entry for entry in enabled_entries
+    }
+    resolved: list[BookEntry] = []
+    seen: set[str] = set()
+    for selected in selected_books:
+        key = _book_entry_identity(selected)
+        if not key or key == ":" or key in seen:
+            continue
+        live = enabled_by_key.get(key)
+        if live is None:
+            continue
+        seen.add(key)
+        # Prefer live merge row (yaml check overlay) over the snapshot from evaluate().
+        resolved.append(live)
+    return resolved
+
+
 def _filter_books_for_trigger(
     book_entries: list[BookEntry],
     cfg: SubscriptionConfig,
@@ -838,9 +934,11 @@ def _filter_books_for_trigger(
     *,
     trigger: str,
 ) -> list[BookEntry]:
-    """Primary: enabled ∩ effective_slot.matches. Catchup/schedule-generic: all enabled.
+    """Primary-like trigger text → slot match. Catchup / generic schedule → all enabled.
 
     Layer C ``is_due`` is intentionally not consulted (D-w6).
+    Hosts should pass ``selected_books`` for primary decisions; this path remains
+    for catchup, manual-adjacent triggers, and unit tests that only set trigger text.
     """
     trigger_text = str(trigger or "").strip().lower()
     primary_like = (
@@ -936,18 +1034,52 @@ def _metadata_book(book: BookInfo, site_episodes: list) -> BookInfo:
 
 
 def _pending_item_rows(pending: _PendingBook) -> list[dict[str, str | int | bool]]:
+    from pathlib import Path
+
+    from utils import conf
+    from utils.core import sanitize_for_path
+
     book = pending.book
+    site = _book_site_key(book)
+    title = str(getattr(book, "name", "") or "")
+    source_url = str(
+        getattr(book, "url", "") or getattr(book, "preview_url", "") or ""
+    ).strip()
+    source_id = f"book:{site}:{source_url}" if site and source_url else ""
+    cover_url = str(getattr(book, "img_preview", "") or "").strip()
+    book_local = str(getattr(book, "local_path", "") or "").strip()
+    if not book_local and title:
+        candidate = Path(conf.sv_path).joinpath(sanitize_for_path(title))
+        if candidate.is_dir():
+            book_local = str(candidate)
     rows = []
     for episode in pending.pending_episodes:
         item_id = str(getattr(episode, "id", "") or getattr(episode, "name", "") or "")
+        episode_name = str(getattr(episode, "name", "") or item_id)
+        local_path = str(getattr(episode, "local_path", "") or "").strip()
+        if not local_path and book_local and episode_name:
+            # Only accept a *chapter* directory. Never fall back to the book root —
+            # that would mark every episode "finished" when any chapter exists.
+            episode_dir = Path(book_local).joinpath(sanitize_for_path(episode_name))
+            if episode_dir.is_dir():
+                local_path = str(episode_dir)
+        status = "finished" if local_path and Path(local_path).is_dir() else "queued"
         rows.append(
             {
                 "item_id": item_id,
-                "book": str(getattr(book, "name", "") or ""),
-                "site": _book_site_key(book),
-                "episode": str(getattr(episode, "name", "") or item_id),
+                # Dual keys: presentation historically read ``title``; keep ``book`` for old readers.
+                "title": title,
+                "book": title,
+                "site": site,
+                "source_id": source_id,
+                "source_url": source_url,
+                "cover_url": cover_url,
+                "episode": episode_name,
                 "pages": int(getattr(episode, "pages", 0) or 0),
-                "submitted": False,
+                "status": status,
+                "stage": "Diff" if status == "queued" else "Submit",
+                "submitted": status == "finished",
+                "local_path": local_path,
             }
         )
     return rows

--- a/utils/tray/subscription_scheduler.py
+++ b/utils/tray/subscription_scheduler.py
@@ -18,7 +18,6 @@ from typing import Callable, Optional
 from utils import temp_p
 from utils.subscription import PRESET_INTERVAL_HOURS, SubscriptionConfig
 from utils.subscription.check_slot import effective_slot
-from utils.subscription.library import LocalLibraryStore
 from utils.subscription.schema import BookEntry, CheckSlot, format_tz_offset_label, format_weekdays_label
 from utils.subscription.store import get_subscription_catchup_preset
 from utils.tray.feature_search import supported_features
@@ -26,7 +25,10 @@ from utils.tray.feature_search import supported_features
 ConfigLoader = Callable[[], SubscriptionConfig]
 NowProvider = Callable[[], datetime]
 CatchupLoader = Callable[[], str]
-LibraryLoader = Callable[[SubscriptionConfig], list[BookEntry]]
+# Binding book loader: MUST return subscription_*.yml books only (not LocalLibraryStore).
+BindingBookLoader = Callable[[SubscriptionConfig], list[BookEntry]]
+# Backward-compatible alias (name is historical; default is yaml binding, not pkl library).
+LibraryLoader = BindingBookLoader
 
 _STATE_ALLOWED_KEYS = frozenset({"last_run_at", "last_primary_slot_key"})
 
@@ -94,7 +96,11 @@ class SchedulerRunState:
     def remember(self, decision: ScheduleDecision) -> None:
         self.last_run_at = decision.triggered_at
         if decision.slot_key.startswith("primary:"):
-            self.last_primary_slot_key = decision.slot_key
+            # Merge same-day fingerprints so a later card slot (00:43) is not
+            # erased from memory after an earlier fire (00:07), and vice versa.
+            self.last_primary_slot_key = _merge_primary_slot_keys(
+                self.last_primary_slot_key, decision.slot_key
+            )
         self.save()
 
 
@@ -112,7 +118,11 @@ class PrimarySlotPlan:
         last_primary_slot_key: str,
         last_run_at: Optional[datetime],
     ) -> Optional[ScheduleDecision]:
-        matched = self._collect_matches(now)
+        matched = self._collect_matches(
+            now,
+            last_primary_slot_key=last_primary_slot_key,
+            last_run_at=last_run_at,
+        )
         if matched is None:
             return None
         if not self._may_fire(matched, now, last_primary_slot_key, last_run_at):
@@ -147,12 +157,28 @@ class PrimarySlotPlan:
             return None
         return min(candidates)
 
-    def _collect_matches(self, now: datetime) -> Optional[_MatchedPrimary]:
+    def _collect_matches(
+        self,
+        now: datetime,
+        *,
+        last_primary_slot_key: str,
+        last_run_at: Optional[datetime],
+    ) -> Optional[_MatchedPrimary]:
+        """Match due slots that have not already fired today.
+
+        Important: ``CheckSlot.matches`` is cumulative (``>= wall clock``), so at
+        00:43 a 00:07 card still matches. Already-fired fingerprints must be
+        excluded or a later same-day card is blocked by the earlier fire.
+        """
         matched_books: list[BookEntry] = []
         matched_slots: list[CheckSlot] = []
         for entry in self.enabled_entries:
             slot = effective_slot(entry, self.cfg.check)
             if not slot.matches(now):
+                continue
+            if self._same_day_already_fired(
+                slot, now, last_primary_slot_key, last_run_at
+            ):
                 continue
             matched_books.append(entry)
             matched_slots.append(slot)
@@ -162,9 +188,8 @@ class PrimarySlotPlan:
         local_now = anchor.as_local(now)
         fingerprints = sorted({slot.fingerprint() for slot in matched_slots})
         tz_label = format_tz_offset_label(anchor.tz_offset)
-        slot_key = (
-            f"primary:{local_now.date().isoformat()}"
-            f"@{anchor.time}{tz_label}#{'|'.join(fingerprints)}"
+        slot_key = _compose_primary_slot_key(
+            local_now.date().isoformat(), fingerprints, anchor=anchor
         )
         reason = f"primary_card_slots n={len(matched_books)} @ {anchor.time}{tz_label}"
         return _MatchedPrimary(
@@ -182,17 +207,23 @@ class PrimarySlotPlan:
         last_primary_slot_key: str,
         last_run_at: Optional[datetime],
     ) -> bool:
+        # Matched set is already filtered to unfired fingerprints for today.
+        if not matched.books:
+            return False
+        memory_day, memory_fps = _parse_primary_memory(last_primary_slot_key)
+        if not memory_day:
+            return True
+        anchor_day = matched.anchor_slot.as_local(now).date().isoformat()
+        if memory_day != anchor_day:
+            return True
+        matched_fps = {slot.fingerprint() for slot in matched.slots}
+        # Exact same fire payload already recorded.
         if matched.slot_key == last_primary_slot_key:
             return False
-        if last_run_at is None:
-            return True
-        anchor = matched.anchor_slot
-        local_now = anchor.as_local(now)
-        last_local = anchor.as_local(last_run_at)
-        if last_local.date() != local_now.date():
-            return True
-        hour, minute = _parse_time(anchor.time)
-        return (last_local.hour, last_local.minute) < (hour, minute)
+        # Every fingerprint in this decision already counted today.
+        if matched_fps and matched_fps.issubset(memory_fps):
+            return False
+        return True
 
     @staticmethod
     def _same_day_already_fired(
@@ -201,13 +232,19 @@ class PrimarySlotPlan:
         last_primary_slot_key: str,
         last_run_at: Optional[datetime],
     ) -> bool:
-        if last_run_at is None or not last_primary_slot_key:
+        if not last_primary_slot_key:
+            return False
+        memory_day, memory_fps = _parse_primary_memory(last_primary_slot_key)
+        if not memory_day or not memory_fps:
             return False
         local_now = slot.as_local(now)
-        last_local = slot.as_local(last_run_at)
-        if last_local.date() != local_now.date():
+        if memory_day != local_now.date().isoformat():
             return False
-        return slot.fingerprint() in last_primary_slot_key
+        if last_run_at is not None:
+            last_local = slot.as_local(last_run_at)
+            if last_local.date() != local_now.date() and slot.fingerprint() not in memory_fps:
+                return False
+        return slot.fingerprint() in memory_fps
 
 
 class CatchupPlan:
@@ -244,7 +281,12 @@ class CatchupPlan:
 
 
 class SubscriptionScheduler:
-    """Primary = any enabled book whose effective CheckSlot matches; catchup = tray qconfig."""
+    """Primary = any enabled binding book whose effective CheckSlot matches; catchup = tray qconfig.
+
+    Schedule targets always come from ``subscription_*.yml`` via
+    ``schedule_binding_book_entries`` (or an injected binding loader). Never scan
+    whole ``LocalLibraryStore`` bookmarks as the schedule set.
+    """
 
     def __init__(
         self,
@@ -254,11 +296,15 @@ class SubscriptionScheduler:
         state_path: Optional[Path] = None,
         catchup_loader: Optional[CatchupLoader] = None,
         library_loader: Optional[LibraryLoader] = None,
+        binding_loader: Optional[BindingBookLoader] = None,
     ) -> None:
         self._config_loader = config_loader
         self._now_provider = now_provider or datetime.now
         self._catchup_loader = catchup_loader or get_subscription_catchup_preset
-        self._library_loader = library_loader or _default_library_entries
+        # Prefer binding_loader; library_loader kept as legacy kwarg name.
+        self._binding_loader = (
+            binding_loader or library_loader or schedule_binding_book_entries
+        )
         self._state = SchedulerRunState(state_path)
 
     @property
@@ -283,7 +329,8 @@ class SubscriptionScheduler:
         cfg.validate()
         if not cfg.check.auto_download:
             return None
-        enabled = [entry for entry in self._library_loader(cfg) if entry.enabled]
+        # enabled filter stays at call site — binding loader returns full yml books[].
+        enabled = [entry for entry in self._binding_loader(cfg) if entry.enabled]
         primary = PrimarySlotPlan(cfg, enabled).decision_if_due(
             current,
             last_primary_slot_key=self._state.last_primary_slot_key,
@@ -302,7 +349,7 @@ class SubscriptionScheduler:
         current = now if now is not None else self._now_provider()
         cfg = self._config_loader()
         cfg.validate()
-        entries = self._library_loader(cfg)
+        entries = self._binding_loader(cfg)
         enabled = [entry for entry in entries if entry.enabled]
         features = len(supported_features(cfg.features))
         catchup = self._catchup_loader()
@@ -342,8 +389,88 @@ def default_scheduler_state_path() -> Path:
     return temp_p / "subscription_scheduler_state.json"
 
 
-def _default_library_entries(cfg: SubscriptionConfig) -> list[BookEntry]:
-    return LocalLibraryStore().book_entries(yaml_books=cfg.books)
+def schedule_run_scope(
+    detail: str,
+    decision: Optional[ScheduleDecision],
+) -> tuple[str, Optional[tuple[BookEntry, ...]]]:
+    """Map a tray schedule kickoff into runner ``trigger`` + optional book scope.
+
+    - manual (no decision) → full enabled binding books
+    - primary decision with matched_books → only those books
+    - catchup / empty matched_books → full enabled binding; trigger keeps decision reason
+    """
+    if decision is None:
+        return "manual", None
+    trigger = str(decision.reason or detail or "schedule").strip() or "schedule"
+    if decision.matched_books:
+        return trigger, tuple(decision.matched_books)
+    return trigger, None
+
+
+def schedule_binding_book_entries(cfg: SubscriptionConfig) -> list[BookEntry]:
+    """Return ``cfg.books`` from the active ``subscription_*.yml`` binding only.
+
+    Contract (three-surface model):
+    - **SSoT**: yaml ``books[]`` is the sole schedule-target set.
+    - **Not filtered here**: includes disabled rows; callers apply
+      ``if entry.enabled`` (scheduler.evaluate / runner._prepare_entries).
+    - **Never** call ``LocalLibraryStore.book_entries()`` / whole pkl library
+      as a substitute — pkl is display join (cover/title) only.
+    - Empty ``cfg.books`` → ``[]`` (cold binding; do not invent targets).
+    """
+    return list(cfg.books or ())
+
+
+def _compose_primary_slot_key(
+    day_iso: str,
+    fingerprints: list[str] | set[str],
+    *,
+    anchor: Optional[CheckSlot] = None,
+) -> str:
+    fps = sorted({str(item) for item in fingerprints if item})
+    joined = "|".join(fps)
+    if anchor is not None:
+        tz_label = format_tz_offset_label(anchor.tz_offset)
+        return f"primary:{day_iso}@{anchor.time}{tz_label}#{joined}"
+    return f"primary:{day_iso}#{joined}"
+
+
+def _parse_primary_memory(slot_key: str) -> tuple[str, set[str]]:
+    """Extract calendar day + fingerprints from a primary slot_key / memory blob."""
+    text = str(slot_key or "").strip()
+    if not text.startswith("primary:"):
+        return "", set()
+    body = text[len("primary:") :]
+    day = ""
+    fingerprint_blob = ""
+    if "#" in body:
+        head, fingerprint_blob = body.split("#", 1)
+    else:
+        head = body
+    if "@" in head:
+        day = head.split("@", 1)[0].strip()
+    else:
+        day = head.strip()
+    fingerprints = {
+        part.strip() for part in fingerprint_blob.split("|") if part.strip()
+    }
+    return day, fingerprints
+
+
+def _merge_primary_slot_keys(previous: str, incoming: str) -> str:
+    prev_day, prev_fps = _parse_primary_memory(previous)
+    next_day, next_fps = _parse_primary_memory(incoming)
+    if not next_day:
+        return incoming or previous or ""
+    if prev_day and prev_day == next_day:
+        merged = sorted(prev_fps | next_fps)
+    else:
+        merged = sorted(next_fps)
+    # Keep incoming head (time label) for readability; fingerprints are cumulative.
+    if incoming.startswith("primary:") and "#" in incoming:
+        head = incoming.split("#", 1)[0]
+        return f"{head}#{'|'.join(merged)}"
+    return _compose_primary_slot_key(next_day, merged)
 
 
 def _earliest_wall_clock_slot(slots: list[CheckSlot]) -> CheckSlot:

--- a/utils/website/nhentai/__init__.py
+++ b/utils/website/nhentai/__init__.py
@@ -93,6 +93,10 @@ class _NhentaiContract:
     tag_db_path = ori_path.joinpath("__temp/nhentai.db")
     gallery_url_template = f"{index}g/%s/"
     gallery_api_url_template = f"{api_index}/galleries/%s?include=comments%%2Crelated"
+    # Access probe must hit API v2 JSON, not HTML index: homepage is CF-challenged for bare httpx
+    # while /api/v2/* stays open (live matrix + Tsuk1ko nhentai-helper / CGS search path).
+    # Prefer list page used by completer mapping over fixed gallery id (177013 is 404 on v2).
+    access_probe_url = f"{api_index}/galleries?page=1"
 
     @classmethod
     def build_search_url(cls, keyword: str, *, page: int = 1, sort: str = "date") -> str:
@@ -288,12 +292,21 @@ class NhentaiReqer(_NhentaiContract, Cookies, Req):
         return cli
 
     def test_index(self):
+        """Probe crawler-reachable API v2, not browser homepage HTML.
+
+        Competitor paths (Zekfad/Enma/archivist legacy ``/api/gallery/*``) return 403 under
+        current CF; CGS + Tsuk1ko use ``/api/v2/galleries*``. Homepage stays 403 for httpx.
+        """
         try:
-            resp = self.cli.get(self.index, follow_redirects=True, timeout=3.5)
+            resp = self.cli.get(self.access_probe_url, follow_redirects=True, timeout=3.5)
             resp.raise_for_status()
-        except httpx.HTTPError:
+            payload = resp.json()
+        except (httpx.HTTPError, ValueError, TypeError):
             return False
-        return bool(resp.text)
+        if not isinstance(payload, dict):
+            return False
+        result = payload.get("result")
+        return isinstance(result, list)
 
     def _headers(self, *, referer: str | None = None) -> dict:
         return self.with_referer(referer)

--- a/utils/website/providers/jestful.py
+++ b/utils/website/providers/jestful.py
@@ -632,18 +632,27 @@ class JestfulReqer(_JestfulContract, Req):
         self.preview_requests = PreviewRequestSession(self)
 
     async def _enrich_book_from_pop(self, book: JestfulBookInfo):
+        """Best-effort metadata pop. Must not block episode list / download path."""
         book_id = str(book.id or "").strip()
         if not book_id:
             return book
-        owner = self._require_preview_owner()
-        session = self.preview_requests
-        pop_resp = await self.ensure_preview_client().get(
-            session.controller_url("cont.pop", action="pop", id=book_id),
-            headers=session.headers(xhr=True), follow_redirects=True, timeout=12,
-        )
-        pop_resp.raise_for_status()
-        pop_fields = await asyncio.to_thread(owner.parser.parse_book_pop_fields, pop_resp.text, request_url=str(pop_resp.url))
-        owner.parser.apply_pop_fields(book, pop_fields)
+        try:
+            owner = self._require_preview_owner()
+            session = self.preview_requests
+            pop_resp = await self.ensure_preview_client().get(
+                session.controller_url("cont.pop", action="pop", id=book_id),
+                headers=session.headers(xhr=True), follow_redirects=True, timeout=12,
+            )
+            pop_resp.raise_for_status()
+            pop_fields = await asyncio.to_thread(
+                owner.parser.parse_book_pop_fields,
+                pop_resp.text,
+                request_url=str(pop_resp.url),
+            )
+            owner.parser.apply_pop_fields(book, pop_fields)
+        except Exception:
+            # Pop payload is cosmetic (title/cover). Chapter list uses lstc separately.
+            return book
         return book
 
     async def _enrich_books_from_pop(self, books: list[JestfulBookInfo]):
@@ -709,8 +718,10 @@ class JestfulReqer(_JestfulContract, Req):
         book.manga_id = owner_state["manga_id"]
         if owner_state.get("latest_sec"):
             owner.parser.apply_latest_chapter(book, owner_state["latest_sec"])
-        if owner_state.get("cover_url") and not book.img_preview:
-            book.img_preview = owner.parser.normalize_site_resource(owner_state["cover_url"])
+        # Library/yml shells may be bare BookInfo without Manga.img_preview declared.
+        cover_url = owner_state.get("cover_url")
+        if cover_url and not getattr(book, "img_preview", None):
+            book.img_preview = owner.parser.normalize_site_resource(cover_url)
         if owner_state.get("preferred_title"):
             owner.parser.apply_pop_fields(
                 book,

--- a/utils/website/providers/wnacg.py
+++ b/utils/website/providers/wnacg.py
@@ -222,6 +222,23 @@ class WnacgUtils(_WnacgContract, EroUtils, DomainUtils, Previewer):
         self.parser = self.__class__.parser
 
     @classmethod
+    def _proxy_uses_static_domain(cls) -> bool:
+        """Proxy reaches the canonical origin; publish-page cache must not bind runtime."""
+        return bool(getattr(conf, "proxies", None))
+
+    @classmethod
+    def peek_cached_domain(cls):
+        if cls._proxy_uses_static_domain():
+            return None
+        return super().peek_cached_domain()
+
+    @classmethod
+    def get_domain(cls):
+        if cls._proxy_uses_static_domain():
+            return cls.domain
+        return super().get_domain()
+
+    @classmethod
     async def parse_publish_(cls, html_text):
         candidates = cls.parser.extract_publish_domains(html_text)
         hosts = await asyncio.gather(*[cls.test_aviable_domain(domain) for domain in candidates])

--- a/variables/__init__.py
+++ b/variables/__init__.py
@@ -3,7 +3,7 @@
 from enum import IntEnum
 from assets import res
 
-VER = "v2.12.0"
+VER = "v2.12.1-beta"
 
 LANG = {
     "en_US": "English",


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Description
<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Checklist:

* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Have you linted your code locally prior to submission?
* [ ] Have you successfully ran app with your changes locally?

## Sourcery 摘要

准备 v2.12.1-beta 版本，提供可靠的并发媒体下载、基于 YAML 作用域的订阅调度、改进的托盘管理，以及更健壮的运行时生命周期处理。

新功能：
- 添加感知绑定的订阅调度功能，支持配置文件选择、定向主要运行、补齐预设，以及分离的排队中/已下载任务视图。
- 添加更可靠的订阅配置管理，支持基于 YAML 的 CRUD、原子持久化、已启用书籍过滤，以及特定站点的书籍解析。
- 将受管理的 aria2 二进制文件移至用户配置目录，并改进服务器和更新器的生命周期处理。
- 添加主题化托盘菜单、对话框、工具提示和调度面板交互。
- 更新 nhentai 访问探测，并改进提供方元数据和代理行为。

错误修复：
- 通过使用线程本地会话修复并发 curl 图片下载问题，并支持异步媒体完成处理。
- 修复进度卡片更新、订阅删除一致性、服务器子进程托管、过时的启动日志，以及 Windows 更新器进程协调问题。
- 修复基于 HWM 的章节过滤，使计划更新仅包含比本地高水位标记更新的章节。
- 改进 wnacg 代理域名处理、nhentai 探测，以及 jestful 封面/元数据回退行为。

改进：
- 根据处于活动状态的 YAML 绑定，而不是整个本地书库，统一订阅调度和展示逻辑。
- 改进托盘中的调度展示，加入来源元数据、本地章节检测、封面解析、文本省略标签、详情操作，以及适配主题的弹出窗口渲染。

构建：
- 将项目、运行时和文档版本升级至 v2.12.1-beta。

文档：
- 更新 beta 版本和 aria2 存储变更相关的发行说明、变更日志和脚本文档。

杂项：
- 移除已废弃的平台专属 aria2 路径属性，并公开共享的订阅辅助函数。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prepare the v2.12.1-beta release with reliable concurrent media downloads, YAML-scoped subscription scheduling, improved tray management, and stronger runtime lifecycle handling.

New Features:
- Add binding-aware subscription scheduling with profile selection, targeted primary runs, catch-up presets, and separate queued/downloaded work views.
- Add resilient subscription configuration management with YAML-backed CRUD, atomic persistence, enabled-book filtering, and site-specific book resolution.
- Move managed aria2 binaries to the user configuration directory and improve server and updater lifecycle handling.
- Add themed tray menus, dialogs, tooltips, and schedule-panel interactions.
- Update nhentai access probing and improve provider metadata and proxy behavior.

Bug Fixes:
- Fix concurrent curl image downloads by using thread-local sessions and support asynchronous media completion.
- Fix progress-card updates, subscription deletion consistency, server child hosting, stale boot logs, and Windows updater process coordination.
- Fix HWM-based episode filtering so scheduled updates include only chapters newer than the local high-water mark.
- Improve wnacg proxy domain handling, nhentai probing, and jestful cover/metadata fallback behavior.

Enhancements:
- Align subscription scheduling and presentation with active YAML bindings rather than the entire local library.
- Improve tray schedule presentation with source metadata, local chapter detection, cover resolution, elided labels, detail actions, and theme-aware popup rendering.

Build:
- Bump the project, runtime, and documentation version to v2.12.1-beta.

Documentation:
- Refresh release notes, changelog, and script documentation for the beta release and aria2 storage changes.

Chores:
- Remove obsolete platform-specific aria2 path properties and expose shared subscription helpers.

</details>